### PR TITLE
Add option to specify filename for instances in GameInstanceGenerator (cleaned)

### DIFF
--- a/clemgame/clemgame.py
+++ b/clemgame/clemgame.py
@@ -838,12 +838,12 @@ class GameInstanceGenerator(GameResourceLocator):
     def on_generate(self):
         raise NotImplementedError()
 
-    def generate(self):
+    def generate(self, filename="instances.json"):
         self.on_generate()
-        self.store()
+        self.store(filename)
 
-    def store(self):
-        self.store_file(self.instances, "instances.json", sub_dir="in")
+    def store(self, filename):
+        self.store_file(self.instances, filename, sub_dir="in")
 
 
 def load_benchmarks(do_setup: bool = True) -> List[GameBenchmark]:

--- a/clemgame/clemgame.py
+++ b/clemgame/clemgame.py
@@ -840,9 +840,6 @@ class GameInstanceGenerator(GameResourceLocator):
 
     def generate(self, filename="instances.json"):
         self.on_generate()
-        self.store(filename)
-
-    def store(self, filename):
         self.store_file(self.instances, filename, sub_dir="in")
 
 


### PR DESCRIPTION
As a first step towards https://github.com/clp-research/clembench/issues/12, GameInstanceGenerator.generate() can now be given a file name to create different versions of instances in in/ (default is set to "instances.json" as before)