### PR TITLE
Adding google/gemma-7b-it HF-local support

### DIFF
--- a/backends/model_registry.json
+++ b/backends/model_registry.json
@@ -384,5 +384,13 @@
     "huggingface_id": "meta-llama/llama-2-70b-chat-hf",
     "premade_chat_template": true,
     "eos_to_cull": "</s>"
+  },
+  {
+    "model_name": "gemma-7b-it",
+    "backend": "huggingface_local",
+    "requires_api_key": true,
+    "huggingface_id": "google/gemma-7b-it",
+    "premade_chat_template": true,
+    "eos_to_cull": "<end_of_turn>"
   }
 ]

--- a/backends/model_registry.json
+++ b/backends/model_registry.json
@@ -391,6 +391,6 @@
     "requires_api_key": true,
     "huggingface_id": "google/gemma-7b-it",
     "premade_chat_template": true,
-    "eos_to_cull": "<end_of_turn>"
+    "eos_to_cull": "<eos>"
   }
 ]

--- a/requirements_hf.txt
+++ b/requirements_hf.txt
@@ -1,6 +1,6 @@
 # Local Backends
 torch==2.0.1 # fix pytorch version
-transformers==4.36.0 # Huggingfaces
+transformers==4.38.2 # Huggingfaces
 sentencepiece==0.1.99 # FLAN model
 accelerate==0.25.0 # FLAN model
 einops==0.6.1 # FALCON model


### PR DESCRIPTION
Requires updating `transformers` to version 4.38.2 for needed classes.