### PR TITLE
add option to set results dir

### DIFF
--- a/clemgame/benchmark.py
+++ b/clemgame/benchmark.py
@@ -27,7 +27,7 @@ def list_games():
 
 
 def run(game_name: str, model_specs: List[backends.ModelSpec], gen_args: Dict,
-        experiment_name: str = None, instances_name: str = None):
+        experiment_name: str = None, instances_name: str = None, results_dir: str = None):
     if experiment_name:
         logger.info("Only running experiment: %s", experiment_name)
     try:
@@ -42,7 +42,7 @@ def run(game_name: str, model_specs: List[backends.ModelSpec], gen_args: Dict,
         if experiment_name:
             benchmark.filter_experiment.append(experiment_name)
         time_start = datetime.now()
-        benchmark.run(player_models=player_models)
+        benchmark.run(player_models=player_models, results_dir=results_dir)
         time_end = datetime.now()
         logger.info(f"Run {benchmark.name} took {str(time_end - time_start)}")
     except Exception as e:
@@ -50,7 +50,7 @@ def run(game_name: str, model_specs: List[backends.ModelSpec], gen_args: Dict,
         logger.error(e, exc_info=True)
 
 
-def score(game_name: str, experiment_name: str = None):
+def score(game_name: str, experiment_name: str = None, results_dir: str = None):
     logger.info("Scoring benchmark for: %s", game_name)
     if experiment_name:
         logger.info("Only scoring experiment: %s", experiment_name)
@@ -65,7 +65,7 @@ def score(game_name: str, experiment_name: str = None):
                 benchmark.filter_experiment.append(experiment_name)
             stdout_logger.info(f"Score game {idx + 1} of {total_games}: {benchmark.name}")
             time_start = datetime.now()
-            benchmark.compute_scores()
+            benchmark.compute_scores(results_dir)
             time_end = datetime.now()
             logger.info(f"Score {benchmark.name} took {str(time_end - time_start)}")
         except Exception as e:
@@ -73,7 +73,7 @@ def score(game_name: str, experiment_name: str = None):
             logger.error(e, exc_info=True)
 
 
-def transcripts(game_name: str, experiment_name: str = None):
+def transcripts(game_name: str, experiment_name: str = None, results_dir: str = None):
     logger.info("Building benchmark transcripts for: %s", game_name)
     if experiment_name:
         logger.info("Only transcribe experiment: %s", experiment_name)
@@ -88,7 +88,7 @@ def transcripts(game_name: str, experiment_name: str = None):
                 benchmark.filter_experiment.append(experiment_name)
             stdout_logger.info(f"Transcribe game {idx + 1} of {total_games}: {benchmark.name}")
             time_start = datetime.now()
-            benchmark.build_transcripts()
+            benchmark.build_transcripts(results_dir)
             time_end = datetime.now()
             logger.info(f"Building transcripts {benchmark.name} took {str(time_end - time_start)}")
         except Exception as e:

--- a/clemgame/file_utils.py
+++ b/clemgame/file_utils.py
@@ -12,12 +12,15 @@ def game_dir(game_name: str) -> str:
     return os.path.join(project_root(), "games", game_name)
 
 
-def results_root() -> str:
-    return os.path.join(project_root(), "results")
+def results_root(results_dir: str = None) -> str:
+    results_dir = "results" if results_dir is None else results_dir
+    if os.path.isabs(results_dir):
+        return results_dir
+    return os.path.join(project_root(), results_dir)
 
 
-def game_results_dir_for(dialogue_pair: str, game_name: str) -> str:
-    return os.path.join(results_root(), dialogue_pair, game_name)
+def game_results_dir_for(results_dir: str, dialogue_pair: str, game_name: str) -> str:
+    return os.path.join(results_root(results_dir), dialogue_pair, game_name)
 
 
 def load_json(file_name: str, game_name: str) -> Dict:
@@ -57,24 +60,28 @@ def load_file(file_name: str, game_name: str = None, file_ending: str = None) ->
     return data
 
 
-def load_results_json(file_name: str, dialogue_pair: str, game_name: str) -> Dict:
-    data = load_results_file(file_name, dialogue_pair, game_name, file_ending=".json")
+def load_results_json(file_name: str, results_dir: str, dialogue_pair: str, game_name: str) -> Dict:
+    data = __load_results_file(file_name, results_dir, dialogue_pair, game_name, file_ending=".json")
     data = json.loads(data)
     return data
 
 
-def load_results_file(file_name: str, dialogue_pair: str, game_name: str, file_ending: str = None) -> str:
+def __load_results_file(file_name: str, results_dir: str, dialogue_pair: str, game_name: str,
+                        file_ending: str = None) -> str:
     if file_ending and not file_name.endswith(file_ending):
         file_name = file_name + file_ending
-    fp = os.path.join(game_results_dir_for(dialogue_pair, game_name), file_name)
+    game_results_dir = game_results_dir_for(results_dir, dialogue_pair, game_name)
+    fp = os.path.join(game_results_dir, file_name)
     with open(fp, encoding='utf8') as f:
         data = f.read()
     return data
 
 
-def store_game_results_file(data, file_name: str, dialogue_pair: str, game_name: str, sub_dir: str = None,
+def store_game_results_file(data, file_name: str, dialogue_pair: str, game_name: str,
+                            sub_dir: str = None, root_dir: str = None,
                             do_overwrite: bool = True) -> str:
-    return store_file(data, file_name, game_results_dir_for(dialogue_pair, game_name), sub_dir, do_overwrite)
+    game_results_dir = game_results_dir_for(root_dir, dialogue_pair, game_name)
+    return store_file(data, file_name, game_results_dir, sub_dir, do_overwrite)
 
 
 def store_game_file(data, file_name: str, game_name: str, sub_dir: str = None, do_overwrite: bool = True) -> str:

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -59,11 +59,12 @@ def main(args: argparse.Namespace):
                       model_specs=read_model_specs(args.models),
                       gen_args=read_gen_args(args),
                       experiment_name=args.experiment_name,
-                      instances_name=args.instances_name)
+                      instances_name=args.instances_name,
+                      results_dir=args.results_dir)
     if args.command_name == "score":
-        benchmark.score(args.game, experiment_name=args.experiment_name)
+        benchmark.score(args.game, experiment_name=args.experiment_name, results_dir=args.results_dir)
     if args.command_name == "transcribe":
-        benchmark.transcripts(args.game, experiment_name=args.experiment_name)
+        benchmark.transcripts(args.game, experiment_name=args.experiment_name, results_dir=args.results_dir)
 
 
 if __name__ == "__main__":
@@ -98,17 +99,29 @@ if __name__ == "__main__":
                                  "Default: 100.")
     run_parser.add_argument("-i", "--instances_name", type=str, default="instances",
                             help="The instances file name (.json suffix will be added automatically.")
+    run_parser.add_argument("-r", "--results_dir", type=str, default="results",
+                            help="A relative or absolute path to the results root directory. "
+                                 "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                 "When not specified, then the results will be located in './results'")
 
     score_parser = sub_parsers.add_parser("score")
     score_parser.add_argument("-e", "--experiment_name", type=str,
                               help="Optional argument to only run a specific experiment")
     score_parser.add_argument("-g", "--game", type=str,
                               help="A specific game name (see ls).", default="all")
+    score_parser.add_argument("-r", "--results_dir", type=str, default="results",
+                              help="A relative or absolute path to the results root directory. "
+                                   "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                   "When not specified, then the results will be located in './results'")
 
     transcribe_parser = sub_parsers.add_parser("transcribe")
     transcribe_parser.add_argument("-e", "--experiment_name", type=str,
                                    help="Optional argument to only run a specific experiment")
     transcribe_parser.add_argument("-g", "--game", type=str,
                                    help="A specific game name (see ls).", default="all")
+    transcribe_parser.add_argument("-r", "--results_dir", type=str, default="results",
+                                   help="A relative or absolute path to the results root directory. "
+                                        "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                        "When not specified, then the results will be located in './results'")
 
     main(parser.parse_args())


### PR DESCRIPTION
Adds a `-r` option to the cli command to specify a root directory for the results.

The following code works as before with 'results' directory: 
```
run -g taboo -m mock
score -g taboo
transcribe -g taboo
```

The following code creates and uses a sub-directory structure 'results/v1.5/en': 
```
run -g taboo -m mock -r results/v1.5/en
score -g taboo -r results/v1.5/en
transcribe -g taboo -r results/v1.5/en
```

Absolute paths are also possible.