### PR TITLE
Basic direct Model usage documentation

### DIFF
--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -251,7 +251,7 @@ def load_model_registry(_model_registry_path: str = None, is_mandatory=True):
                                     f"Create model registry as a model_registry.json file and try again.")
         else:
             return  # do nothing
-    with open(_model_registry_path) as f:
+    with open(_model_registry_path, encoding='utf-8') as f:
         _model_listing = json.load(f)
         for _model_entry in _model_listing:
             _model_spec: ModelSpec = ModelSpec.from_dict(_model_entry)

--- a/docs/howto_basic_backend_usage.md
+++ b/docs/howto_basic_backend_usage.md
@@ -15,12 +15,9 @@ content. The method returns the full prompt, full output and generated text as a
 Load a supported model and generate a reply:
 ```python
 import backends
-import os
 
-# path to the model registry file, this assumes this script is in the clembench root directory:
-_model_registry_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "backends", "model_registry.json")
 # load the model registry:
-backends.load_model_registry(_model_registry_path)
+backends.load_model_registry()
 
 # model name of the model to be loaded:
 model_name = "zephyr-7b-beta"
@@ -46,12 +43,9 @@ print(response_text)
 Loop over a list of supported model names and generate a reply to the same messages with each:
 ```python
 import backends
-import os
 
-# path to the model registry file, this assumes this script is in the clembench root directory:
-_model_registry_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "backends", "model_registry.json")
 # load the model registry:
-backends.load_model_registry(_model_registry_path)
+backends.load_model_registry()
 
 # model names of the models to be used:
 model_names = ["zephyr-7b-alpha", "zephyr-7b-beta", "openchat-3.5-0106", "gpt-3.5-turbo-0125"]

--- a/docs/howto_basic_backend_usage.md
+++ b/docs/howto_basic_backend_usage.md
@@ -5,29 +5,40 @@ clembench needs to be fully set up, including all requirements of the models to 
 `transformers`-based backend requirements listed in `requirements_hf.txt`. See [the basic howto](howto_run_benchmark.md) 
 for more information, specially for the handling of API keys.
 ## The backends.Model class
-All remote API requests and generation requests to locally run models are handled by child classes of the `backends.Model` 
-class.  
+All remote API requests and generation requests to locally run models are handled by child classes of the 
+`backends.Model` class.  
 All `Model` child classes implement the `generate_response()` method. `generate_response()` expects a `List[Dict]` 
-messages object containing an exchange of chat messages. Each message contains a role and text content. The method 
-returns the full prompt, full output and generated text as a tuple of strings. See [the model addition howto](howto_add_models.md) 
-for more information.
+messages object containing an exchange of chat messages. Each message contains a role ('user' or 'assistant') and text 
+content. The method returns the full prompt, full output and generated text as a tuple of strings. See 
+[the model addition howto](howto_add_models.md) for more information.
 ## Basic example
 Load a supported model and generate a reply:
 ```python
 import backends
+import os
 
+# path to the model registry file, this assumes this script is in the clembench root directory:
+_model_registry_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "backends", "model_registry.json")
+# load the model registry:
+backends.load_model_registry(_model_registry_path)
+
+# model name of the model to be loaded:
 model_name = "zephyr-7b-beta"
-
+# load the model, as a Model subclass instance (HuggingfaceLocalModel in this case):
 model = backends.get_model_for(model_name)
+# set required generation arguments/sampling parameters:
+model.set_gen_arg('temperature', 0.0)  # temperature 0.0 for deterministic sampling
+model.set_gen_arg('max_tokens', 25)  # maximum number of generated tokens
 
+# messages list:
 messages = [
     {'role': "user", 'content': "Hello!"},
     {'role': "assistant", 'content': "Hello! How can I help you?"},
     {'role': "user", 'content': "Tell me the name of the capital of Australia."},
 ]
 
+# generate a response:
 prompt, response, response_text = model.generate_response(messages)
-
 print(f"{model_name} reply:")
 print(response_text)
 ```
@@ -35,20 +46,31 @@ print(response_text)
 Loop over a list of supported model names and generate a reply to the same messages with each:
 ```python
 import backends
+import os
 
+# path to the model registry file, this assumes this script is in the clembench root directory:
+_model_registry_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "backends", "model_registry.json")
+# load the model registry:
+backends.load_model_registry(_model_registry_path)
+
+# model names of the models to be used:
 model_names = ["zephyr-7b-alpha", "zephyr-7b-beta", "openchat-3.5-0106", "gpt-3.5-turbo-0125"]
-
+# messages list:
 messages = [
     {'role': "user", 'content': "Hello!"},
     {'role': "assistant", 'content': "Hello! How can I help you?"},
     {'role': "user", 'content': "Tell me the name of the capital of Australia."},
 ]
-
+# loop over model names list:
 for model_name in model_names:
+    # create a Model subclass instance:
     model = backends.get_model_for(model_name)
+    # set required generation arguments/sampling parameters:
+    model.set_gen_arg('temperature', 0.0)  # temperature 0.0 for deterministic sampling
+    model.set_gen_arg('max_tokens', 25)  # maximum number of generated tokens
     
+    # generate a response:
     prompt, response, response_text = model.generate_response(messages)
-
     print(f"{model_name} reply:")
     print(response_text)
     
@@ -56,8 +78,8 @@ for model_name in model_names:
     del model
 ```
 The removal of `Model` instances may be omitted if enough memory (VRAM) is available to load multiple models locally at 
-the same time. clembench **does not** handle memory demands and limitations, and loading models when remaining memory space is 
-insufficient will lead to `torch`/CUDA crashes.  
+the same time. clembench **does not** handle memory demands and limitations, and loading models when remaining memory 
+space is insufficient will lead to `torch`/CUDA crashes.  
 As remote models accessed via API (like "gpt-3.5-turbo-0125" above) do not require local memory, multiple `Model` 
 instances using these models can be active at the same time without issues.
 ## clembench backends details
@@ -67,13 +89,18 @@ A model is supported by clembench if it has an entry in the [model registry](../
 entries contain all necessary information to load the model and use it to generate chat replies. The model registry 
 supplied on the clembench repository covers tested and working models. See the 
 [model registry documentation](model_backend_registry_readme.md) for more information.
-### ModelSpec class
+### backends.ModelSpec class
 The `backends.ModelSpec` class holds information retrieved from the model registry. In addition, it can store sampling 
 parameters (like temperature). Note: Non-standard sampling parameters must be accepted by specific model backends.
 ### Model chat functionality
 While most remote APIs apply chat formatting server-side, local clembench backends apply model-appropriate chat 
 templates for generation. This assures that the input follows the multi-turn format the model was trained on. The 
-first tuple element returned by `generate_response()` for local models contains the applied formatting.
+first tuple element returned by `generate_response()` for local models contains the applied formatting.  
+The messages list should contain only messages with the roles 'user' and 'assistant' (assumed to be model outputs), 
+ordered in pairs of a 'user' message followed by an 'assistant' message, and end with a 'user' message (as shown in the 
+code examples) for model compatibility and best results. Order issues are handled to a large extent by the backends, but 
+the processing involved may be destructive. System message is only supported by some models - for these, it has to be 
+the first message in the list and have the role 'system'.
 ### backends.get_model_for()
 The `backends.get_model_for()` function takes either a model name, as defined in a model registry entry, a `dict` 
 containing the necessary model information or a `backends.ModelSpec` instance.  
@@ -84,3 +111,15 @@ entries: For example "openchat-3.5", which has a remote 'openai-compatible' entr
 local HuggingFace backend. Using a `dict` also allows to instantiate a model with non-standard sampling parameters 
 directly.  
 See the [backends code](../backends/__init__.py) for the `ModelSpec` class and intermediate uses of it.
+### backends.Model class sampling parameters
+`backends.Model` and its subclasses can store sampling parameters, also called generation arguments. Unless these 
+have been passed by `dict` or `ModelSpec` at initialization, they have to be set using the `set_gen_args()` or 
+`set_gen_arg()` methods of `backends.Model`.  
+`set_gen_args()` takes a single `dict` with `'generation_argument': value` items, to set a number of sampling parameters 
+at once.  
+`set_gen_arg()` takes two arguments, a generation argument name as `string` and the corresponding value, to set 
+individual sampling parameters.  
+The `temperature` and `max_tokens` generation arguments are **mandatory** for all `backends.Model` subclass instances. 
+Both parameters are set by framework and clemgame scripts when clembench is used for benchmarking. For direct use, they 
+have to be set directly, as shown in the example scripts.  
+Support for other sampling parameters depends on specific backends and models, and is not implemented yet.

--- a/docs/howto_basic_backend_usage.md
+++ b/docs/howto_basic_backend_usage.md
@@ -73,10 +73,10 @@ parameters (like temperature). Note: Non-standard sampling parameters must be ac
 ### Model chat functionality
 While most remote APIs apply chat formatting server-side, local clembench backends apply model-appropriate chat 
 templates for generation. This assures that the input follows the multi-turn format the model was trained on. The 
-first tuple element returned by `generate_response()` for the latter contains the applied formatting.
+first tuple element returned by `generate_response()` for local models contains the applied formatting.
 ### backends.get_model_for()
-The `backends.get_model_for()` takes either a model name, as defined in a model registry entry, a `dict` containing the 
-necessary model information or a `backends.ModelSpec` instance.  
+The `backends.get_model_for()` function takes either a model name, as defined in a model registry entry, a `dict` 
+containing the necessary model information or a `backends.ModelSpec` instance.  
 When only a model name is passed (as in the examples above), the first model entry matching the name is retrieved to 
 instantiate a `ModelSpec`, which is used to load the corresponding model.  
 Passing a `dict` allows to select a specific model version. This is useful for models that have multiple registry 

--- a/docs/howto_basic_backend_usage.md
+++ b/docs/howto_basic_backend_usage.md
@@ -1,0 +1,60 @@
+# How to use the clembench model backend directly
+This guide covers using the clembench Model backend class outside of full clemgames.
+## Requirements
+clembench needs to be fully set up, including all requirements of the models to be used, like the HuggingFace 
+`transformers`-based backend requirements listed in `requirements_hf.txt`. See [the basic howto](howto_run_benchmark.md) 
+for more information, specially for the handling of API keys.
+## The backends.Model class
+All remote API requests and generation requests to locally run models are handled by child classes of the `backends.Model` 
+class.  
+All `Model` child classes implement the `generate_response()` method. `generate_response()` expects a `List[Dict]` 
+messages object containing an exchange of chat messages. Each message contains a role and text content. The method 
+returns the full prompt, full output and generated text as a tuple of strings. See [the model addition howto](howto_add_models.md) 
+for more information.
+## Basic example
+Load a supported model and generate a reply:
+```python
+import backends
+
+model_name = "zephyr-7b-beta"
+
+model = backends.get_model_for(model_name)
+
+messages = [
+    {'role': "user", 'content': "Hello!"},
+    {'role': "assistant", 'content': "Hello! How can I help you?"},
+    {'role': "user", 'content': "Tell me the name of the capital of Australia."},
+]
+
+prompt, response, response_text = model.generate_response(messages)
+
+print(f"{model_name} reply:")
+print(response_text)
+```
+## Multiple models example
+Loop over a list of supported model names and generate a reply to the same messages with each:
+```python
+import backends
+
+model_names = ["zephyr-7b-alpha", "zephyr-7b-beta", "openchat-3.5-0106"]
+
+messages = [
+    {'role': "user", 'content': "Hello!"},
+    {'role': "assistant", 'content': "Hello! How can I help you?"},
+    {'role': "user", 'content': "Tell me the name of the capital of Australia."},
+]
+
+for model_name in model_names:
+    model = backends.get_model_for(model_name)
+    
+    prompt, response, response_text = model.generate_response(messages)
+
+    print(f"{model_name} reply:")
+    print(response_text)
+    
+    # remove Model instance to free up memory:
+    del model
+```
+The removal of `Model` instances may be omitted if enough memory (VRAM) is available to load multiple models at the same 
+time. clembench **does not** handle memory demands and limitations, and loading models when remaining memory space is 
+insufficient will lead to `torch`/CUDA crashes.

--- a/docs/howto_basic_backend_usage.md
+++ b/docs/howto_basic_backend_usage.md
@@ -36,7 +36,7 @@ Loop over a list of supported model names and generate a reply to the same messa
 ```python
 import backends
 
-model_names = ["zephyr-7b-alpha", "zephyr-7b-beta", "openchat-3.5-0106"]
+model_names = ["zephyr-7b-alpha", "zephyr-7b-beta", "openchat-3.5-0106", "gpt-3.5-turbo-0125"]
 
 messages = [
     {'role': "user", 'content': "Hello!"},
@@ -55,6 +55,32 @@ for model_name in model_names:
     # remove Model instance to free up memory:
     del model
 ```
-The removal of `Model` instances may be omitted if enough memory (VRAM) is available to load multiple models at the same 
-time. clembench **does not** handle memory demands and limitations, and loading models when remaining memory space is 
-insufficient will lead to `torch`/CUDA crashes.
+The removal of `Model` instances may be omitted if enough memory (VRAM) is available to load multiple models locally at 
+the same time. clembench **does not** handle memory demands and limitations, and loading models when remaining memory space is 
+insufficient will lead to `torch`/CUDA crashes.  
+As remote models accessed via API (like "gpt-3.5-turbo-0125" above) do not require local memory, multiple `Model` 
+instances using these models can be active at the same time without issues.
+## clembench backends details
+While the clembench backends can simply be used as shown above, certain implementation details may be helpful.
+### Supported Models & Model Registry
+A model is supported by clembench if it has an entry in the [model registry](../backends/model_registry.json). Model 
+entries contain all necessary information to load the model and use it to generate chat replies. The model registry 
+supplied on the clembench repository covers tested and working models. See the 
+[model registry documentation](model_backend_registry_readme.md) for more information.
+### ModelSpec class
+The `backends.ModelSpec` class holds information retrieved from the model registry. In addition, it can store sampling 
+parameters (like temperature). Note: Non-standard sampling parameters must be accepted by specific model backends.
+### Model chat functionality
+While most remote APIs apply chat formatting server-side, local clembench backends apply model-appropriate chat 
+templates for generation. This assures that the input follows the multi-turn format the model was trained on. The 
+first tuple element returned by `generate_response()` for the latter contains the applied formatting.
+### backends.get_model_for()
+The `backends.get_model_for()` takes either a model name, as defined in a model registry entry, a `dict` containing the 
+necessary model information or a `backends.ModelSpec` instance.  
+When only a model name is passed (as in the examples above), the first model entry matching the name is retrieved to 
+instantiate a `ModelSpec`, which is used to load the corresponding model.  
+Passing a `dict` allows to select a specific model version. This is useful for models that have multiple registry 
+entries: For example "openchat-3.5", which has a remote 'openai-compatible' entry and an entry for running it on the 
+local HuggingFace backend. Using a `dict` also allows to instantiate a model with non-standard sampling parameters 
+directly.  
+See the [backends code](../backends/__init__.py) for the `ModelSpec` class and intermediate uses of it.

--- a/docs/howto_run_benchmark.md
+++ b/docs/howto_run_benchmark.md
@@ -31,23 +31,11 @@ Note: You can look up your api key for OpenAI at https://platform.openai.com/acc
 at https://console.anthropic.com/account/keys, AlephAlpha can be found
 here: https://docs.aleph-alpha.com/docs/introduction/luminous/
 
-### Available models
+### Supported models
 
-Currently available values are:
-
-- `"gpt-4"`
-- `"gpt-3.5-turbo"`
-- `"text-davinci-003"`
-- `"claude-v1.3"`
-- `"claude-v1.3-100k"`
-- `"luminous-supreme-control"`
-- `"luminous-supreme"`
-- `"luminous-extended"`
-- `"luminous-base"`
-- `"google/flan-t5-xxl"`
-
-Models can be added in `clemgame/api.py`.
-
+Supported models are listed in the [model registry](../backends/model_registry.json).  
+To use a supported model as shown below, use the model registry entry's `model_name`.  
+See the [model registry documentation](model_backend_registry_readme.md) for more information.
 
 ## Validating your installation
 


### PR DESCRIPTION
New .MD covering directly using backends.Model for generation.
Also comes with a small change to backends.__init__.py to force loading the model registry JSON as UTF-8 - to allow simple one-line loading of the model registry in howto_basic_backend_usage.md.