### PR TITLE
Add model OpenAI gpt-4-vision-preview

### DIFF
--- a/backends/model_registry.json
+++ b/backends/model_registry.json
@@ -85,6 +85,12 @@
     "backend": "openai"
   },
   {
+    "model_name": "gpt-4-vision-preview",
+    "model_id": "gpt-4-vision-preview",
+    "backend": "openai",
+    "vision": true
+  },
+  {
     "model_name": "mistral-medium-2312",
     "model_id": "mistral-medium-2312",
     "backend": "mistral"

--- a/backends/openai_api.py
+++ b/backends/openai_api.py
@@ -57,21 +57,24 @@ class OpenAIModel(backends.Model):
                         }
                 ]}
             if "image" in message.keys():
-                url, loaded = self.encode_image(message["image"])
-                if url:
-                    this["content"].append({
-                        "type": "image_url",
-                        "image_url": {
-                            "url": loaded
-                        }
-                    })
-                else:
-                    this["content"].append({
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:image/jpeg;base64,{loaded}"
-                        }
-                    })
+                if isinstance(message['image'], str):
+                    message['image'] = [message['image']]
+                for img in message['image']:
+                    url, loaded = self.encode_image(img)
+                    if url:
+                        this["content"].append({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": loaded
+                            }
+                        })
+                    else:
+                        this["content"].append({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{loaded}"
+                            }
+                        })
             vision_messages.append(this)
         return vision_messages
 

--- a/backends/openai_api.py
+++ b/backends/openai_api.py
@@ -36,9 +36,6 @@ class OpenAIModel(backends.Model):
     def __init__(self, client: openai.OpenAI, model_spec: backends.ModelSpec):
         super().__init__(model_spec)
         self.client = client
-        self.is_vision = False
-        if model_spec.has_attr("vision"):
-            self.is_vision = self.model_spec["vision"]
         
     def encode_image(self, image_path):
         if image_path.startswith('http'):
@@ -49,33 +46,25 @@ class OpenAIModel(backends.Model):
     def apply_vision_format(self, messages):
         vision_messages = []
         for message in messages:
-            this = {"role": message["role"], 
+            vision_message = {"role": message["role"], 
                     "content": [
                         {
                             "type": "text",
                             "text": message["content"]
                         }
                 ]}
-            if "image" in message.keys():
+            if "image" in message:
                 if isinstance(message['image'], str):
                     message['image'] = [message['image']]
                 for img in message['image']:
                     url, loaded = self.encode_image(img)
-                    if url:
-                        this["content"].append({
-                            "type": "image_url",
-                            "image_url": {
-                                "url": loaded
-                            }
-                        })
-                    else:
-                        this["content"].append({
-                            "type": "image_url",
-                            "image_url": {
-                                "url": f"data:image/jpeg;base64,{loaded}"
-                            }
-                        })
-            vision_messages.append(this)
+                    vision_message["content"].append({
+                        "type": "image_url",
+                        "image_url": {
+                            "url": loaded if url else f"data:image/jpeg;base64,{loaded}"
+                        }
+                    })
+            vision_messages.append(vision_message)
         return vision_messages
 
     @retry(tries=3, delay=0, logger=logger)
@@ -91,8 +80,9 @@ class OpenAIModel(backends.Model):
                 ]
         :return: the continuation
         """
-        if self.is_vision:
-            messages = self.apply_vision_format(messages)
+        if self.model_spec.has_attr("vision"):
+            if self.model_spec["vision"]:
+                messages = self.apply_vision_format(messages)
         prompt = messages
         api_response = self.client.chat.completions.create(model=self.model_spec.model_id,
                                                            messages=prompt,

--- a/backends/openai_api.py
+++ b/backends/openai_api.py
@@ -53,7 +53,7 @@ class OpenAIModel(backends.Model):
                     "content": [
                         {
                             "type": "text",
-                            "text": message["content"].replace(" <image> ", " ")
+                            "text": message["content"]
                         }
                 ]}
             if "image" in message.keys():

--- a/clemgame/clemgame.py
+++ b/clemgame/clemgame.py
@@ -488,16 +488,18 @@ class DialogueGameMaster(GameMaster):
         action = {'type': type_, 'content': value}
         self.log_event("GM", "GM", action)
 
-    def add_message(self, player: Player, utterance: str, role: str):
+    def add_message(self, player: Player, utterance: str, role: str, **kwargs: Dict):
         message = {"role": role, "content": utterance}
+        if "image" in kwargs:
+            message['image'] = kwargs['image']
         history = self.messages_by_names[player.descriptor]
         history.append(message)
 
-    def add_user_message(self, player: Player, utterance: str):
-        self.add_message(player, utterance, role="user")
+    def add_user_message(self, player: Player, utterance: str, **kwargs: Dict):
+        self.add_message(player, utterance, role="user", **kwargs)
 
-    def add_assistant_message(self, player: Player, utterance: str):
-        self.add_message(player, utterance, role="assistant")
+    def add_assistant_message(self, player: Player, utterance: str, **kwargs: Dict):
+        self.add_message(player, utterance, role="assistant", **kwargs)
 
     def __validate_parse_and_add_player_response(self, player: Player, utterance: str):
         # todo: it seems we should change the order here: Parse should come first, and then validate.


### PR DESCRIPTION
I have extended the OpenAI backend and model_registry to support OpenAI's multimodal version of gpt-4. This also needed a small change to the way messages are added by allowing users to pass images (file path or link) to the add_message function via the optional keywork 'image'. I am using keyword arguments for this to make it easily extendable to other modalities (video, audio ...) and combinations of them. While most open models only support one image per user message, gpt-4v also takes multiple images in a single message. Hence the value of the 'image' argument needs to be a string or a list of strings. Since the format in which messages are passed to the model differes from other OpenAI models, I added a new value to the model_registry which indicated if this other messages format needs to be aplied.