### PR TITLE
Hardcode hotfix to handle model entry eos_to_cull containing "|"

### DIFF
--- a/backends/huggingface_local_api.py
+++ b/backends/huggingface_local_api.py
@@ -234,7 +234,12 @@ class HuggingfaceLocalModel(backends.Model):
 
             # remove eos token string:
             eos_to_cull = self.model_spec['eos_to_cull']
-            response_text = re.sub(eos_to_cull, "", response_text)
+            if "|" in eos_to_cull:
+                eos_len = len(eos_to_cull)
+                if response_text.endswith(eos_to_cull):
+                    response_text = response_text[:-eos_len]
+            else:
+                response_text = re.sub(eos_to_cull, "", response_text)
         else:
             response_text = model_output.strip()
 


### PR DESCRIPTION
...without using regEx, using prior more robust culling code.
This is a crude hotfix, intended to allow student project work to continue as soon as possible - it should be merged as quickly as possible, while the handling of the issue should be properly discussed in this issue: https://github.com/clp-research/clembench/issues/118