### PR TITLE
Fix wrong "eos_to_cull" in salamandra-7b-instruct model registry entry

### DIFF
--- a/backends/model_registry.json
+++ b/backends/model_registry.json
@@ -1203,7 +1203,7 @@
       "backend": "huggingface_local",
       "huggingface_id": "BSC-LT/salamandra-7b-instruct",
       "premade_chat_template": true,
-      "eos_to_cull": "</s>",
+      "eos_to_cull": "<\\|im_end\\|>",
       "release_date": "2024-09-30",
       "open_weight": true,
       "parameters": "7B"


### PR DESCRIPTION
Change "eos_to_cull" "</s>" to "<\\|im_end\\|>"