### PR TITLE
Compatibility Patch for Playpen and Legacy Clembench Games

### DIFF
--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -1,4 +1,5 @@
-from clemcore.clemgame.errors import GameError, ParseError, RuleViolationError
+from clemcore.clemgame.errors import GameError, ParseError, RuleViolationError, ResponseError, ProtocolError, \
+    NotApplicableError
 from clemcore.clemgame.instances import GameInstanceGenerator
 from clemcore.clemgame.resources import GameResourceLocator
 from clemcore.clemgame.master import GameMaster, DialogueGameMaster, EnvGameMaster, Player
@@ -7,7 +8,6 @@ from clemcore.clemgame.recorder import DefaultGameRecorder, GameRecorder
 from clemcore.clemgame.registry import GameSpec, GameRegistry
 from clemcore.clemgame.benchmark import GameBenchmark, GameInstanceIterator
 from clemcore.clemgame.environment import Action, ActionSpace, GameEnvironment, GameState, Observation
-
 
 __all__ = [
     "GameBenchmark",
@@ -28,7 +28,10 @@ __all__ = [
     "DefaultGameRecorder",
     "GameResourceLocator",
     "GameInstanceIterator",
-    "GameError",
+    "ResponseError",
+    "ProtocolError",
     "ParseError",
-    "RuleViolationError"
+    "GameError",
+    "RuleViolationError",
+    "NotApplicableError"
 ]

--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -1,6 +1,7 @@
+from clemcore.clemgame.errors import GameError, ParseError, RuleViolationError
 from clemcore.clemgame.instances import GameInstanceGenerator
 from clemcore.clemgame.resources import GameResourceLocator
-from clemcore.clemgame.master import GameMaster, DialogueGameMaster, EnvGameMaster, Player, GameError, ParseError, RuleViolationError
+from clemcore.clemgame.master import GameMaster, DialogueGameMaster, EnvGameMaster, Player
 from clemcore.clemgame.metrics import GameScorer
 from clemcore.clemgame.recorder import DefaultGameRecorder, GameRecorder
 from clemcore.clemgame.registry import GameSpec, GameRegistry

--- a/clemcore/clemgame/errors.py
+++ b/clemcore/clemgame/errors.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+
+class ResponseError(Exception):
+    """
+    General error class for problems with the player response.
+
+    Developers can introduce more specific error types by subclassing this error.
+    Alternatively, the 'key' attribute can be used to define more granular error types.
+    """
+
+    def __init__(self, reason: Optional[str] = None, response: Optional[str] = None, key: Optional[str] = None):
+        """
+        :param reason: (optional) a brief description of the cause
+        :param response: (optional) the player's response
+        :param key: (optional) a key word
+        """
+        super().__init__(reason)
+        self.reason = reason
+        self.response = response
+        self.key = key
+
+    def __str__(self):
+        return f"{self.__class__.__name__}: {self.reason}"
+
+
+class ProtocolError(ResponseError):
+    """Raised when a message does not follow the communication protocol expected by the game master."""
+    pass
+
+
+class ParseError(ProtocolError):
+    """
+    This error is supposed to be raised when player messages cannot be parsed or understood by the game master e.g.
+    because the response does not start with a specified prefix.
+
+    For example:
+        - taboo: clue giver messages should start with 'CLUE:'
+        - wordle: guesser messages should start with 'GUESS:'
+    """
+    pass
+
+
+class GameError(ResponseError):
+    """Raised when a verbal action of a player causes problems for advancing the game."""
+    pass
+
+
+class RuleViolationError(GameError):
+    """Raised when a verbal action of a player violates the specified game rules.
+
+    For example:
+        - taboo: mentioning the target word as the clue giver
+        - wordle: guessing words that are not exactly 5 letters long
+    """
+    pass
+
+
+class NotApplicableError(GameError):
+    """Raised when a verbal action of a player cannot be applied to advance the game state."""
+    pass

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -1,0 +1,340 @@
+import abc
+import collections
+from copy import deepcopy
+from typing import List, Dict, Tuple, Union
+
+from clemcore import backends
+from clemcore.clemgame.master import GameMaster
+from clemcore.clemgame.registry import GameSpec
+from clemcore.clemgame.player import Player
+
+
+class DialogueGameMaster(GameMaster):
+    """Extended GameMaster, implementing turns as described in the clembench paper.
+    Has most logging and gameplay procedures implemented, including convenient logging methods.
+    """
+
+    def __init__(self, game_spec: GameSpec, experiment: dict, player_models: List[backends.Model]):
+        """
+        Args:
+            name: The name of the game (as specified in game_registry).
+            path: Path to the game (as specified in game_registry).
+            experiment: The experiment (set of instances) to use.
+            player_models: Player models to use for one or two players.
+        """
+        super().__init__(game_spec, experiment, player_models)
+        # the logging works with an internal mapping of "Player N" -> Player
+        self.players_by_names: Dict[str, Player] = collections.OrderedDict()
+        self.context_for_player: Dict[str, Dict] = dict()  # context entries look like {"role":"user", "content": ...}
+        self.current_round: int = 0
+        self._current_player: Player = None
+        self._current_player_idx: int = 0
+        self.info = {}
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        for player in self.players_by_names.values():  # sync game recorders (not copied in Player)
+            player.game_recorder = self.game_recorder
+
+    @property
+    def current_player(self) -> Player:
+        return self._current_player
+
+    def get_players(self) -> List[Player]:
+        """Get a list of the players.
+        Returns:
+            List of Player instances in the order they are added.
+        """
+        return list(self.players_by_names.values())
+
+    def add_player(self, player: Player, initial_prompt: Union[str, Dict] = None,
+                   initial_context: Union[str, Dict] = None):
+        """Add a player to the game. The same player cannot be added twice.
+        The player identity is determined by the player's name.
+
+        Important: During gameplay, the players will be called in the same order as added to the game master!
+
+        Args:
+            player: The player to be added to the game. The player's name must be unique.
+            initial_prompt: The initial prompt given to the player (optional). See Player for more details.
+            initial_context: A context to be immediately set for the player (optional). This is useful for initial
+                            prompts that are supposed to be handled as the first context, for example, when adding
+                            the other player's response to the prompt is not necessary, but the player is supposed
+                            to directly react to the initial prompt. Alternatively, overwrite on_before_game() and
+                            use set_context_for(player) to set the player context.
+        """
+        player.game_recorder = self.game_recorder  # player should record to the same interaction log
+        player.initial_prompt = initial_prompt
+        player.name = f"Player {len(self.players_by_names) + 1}"
+        if player.name in self.players_by_names:
+            raise ValueError(f"Player names must be unique, "
+                             f"but there is already a player registered with name '{player.name}'.")
+        self.players_by_names[player.name] = player
+        self.log_player(player)
+        if initial_context is not None:
+            assert isinstance(initial_context, (str, dict)), \
+                f"The initial context must be a str or dict, but is {type(initial_context)}"
+            if isinstance(initial_context, dict):
+                assert "content" in initial_context, "The initial context requires a content entry"
+                extras = {k: v for k, v in initial_context.items() if k not in ["role", "content"]}
+                self.set_context_for(player, initial_context["content"], **extras)
+            else:
+                self.set_context_for(player, initial_context)
+
+    def setup(self, **kwargs):
+        """Load resources and prepare everything to play the game.
+        Needs to log the players dictionary via self.log_players(players_dict).
+        Intended to be left as-is by inheriting classes. Implement game-specific setup functionality in the _on_setup
+        method.
+        Called by the game's GameBenchmark run method for each game instance.
+        Args:
+            kwargs: Keyword arguments used to set up the GameMaster instance. This is usually a game instance object
+                read from the game's instances.json.
+        """
+        self._on_setup(**kwargs)
+        self._current_player = self.get_players()[self._current_player_idx]
+        self._on_before_game()
+        self._on_before_round()
+
+    @abc.abstractmethod
+    def _on_setup(self, **kwargs):
+        """Method executed at the start of the default setup method.
+        Template method: Must be implemented!
+        Use add_player() here to add the players.
+        Args:
+            kwargs: Keyword arguments of the game instance. This is usually a game instance object
+                read from the game's instances.json.
+        """
+        pass
+
+    def get_game_state(self):
+        return None
+
+    def get_current_player(self) -> Player:
+        return self.current_player
+
+    def set_context_for(self, player: Player, content: str, **extras):
+        """
+        Set the context for the specified Player. The player will be prompted with the context on its next turn.
+
+        The context always has a 'role' and 'content' entry where the 'role' is always set to 'user'.
+        Args:
+            player: The player to set the context for.
+            content: The text content to be added to the context.
+            extras: Additional content to be merged into the context e.g. information about images
+        """
+        if player is None:
+            return
+        message = {"role": "user", "content": content}
+        context = {**extras, **message}
+        self.context_for_player[player.name] = context
+
+    def get_context_for(self, player) -> Dict:
+        assert player is not None, "Cannot get player context for 'None'"
+        assert player.name in self.context_for_player, f"No context set for {player.name}"
+        context = self.context_for_player[player.name]
+        assert "role" in context, f"Player context must have a 'role' entry"
+        assert context["role"] == "user", f"Role of player context must be 'user'"
+        assert "content" in context, f"Player context must have a 'content' entry"
+        return context
+
+    def play(self) -> None:
+        """
+        Main play loop method. This method is called to run the game for benchmarking.
+        """
+        done = False
+        while not done:
+            context = self.get_context_for(self.current_player)
+            response = self.current_player(context)
+            done, _ = self.step(response)
+
+    def step(self, response: str) -> Tuple[bool, Dict]:
+        """
+        Transitions the game state by applying the current player's response.
+
+        :param response: The response (verbal action) of the current player.
+        :return: done, info
+        """
+        # compute scores first, so that we are sure that the player's context
+        # can still be retrieved (state has not changed yet)
+        context = self.get_context_for(self.current_player)
+        self.info["response_score"] = self.compute_response_score(response, context)
+        self.info["response_feedback"] = self.get_response_feedback(response, context)
+        self.info["episode_score"] = 0
+
+        # todo: it seems we should change the order here: Parse should come first, and then validate.
+        # While parse might throw a parsing (format error) validate would check solely for satisfied game rules.
+        # Note: this would allow to cut off too long responses (during parse) and to only validate on the cut off piece.
+        if self._validate_player_response(self.current_player, response):
+            parsed_response = self._parse_response(self.current_player, response)
+            self._on_valid_player_response(self.current_player, parsed_response)
+
+        # determine if the current player should pass the turn to the next player or get another turn:
+        if self._should_pass_turn():  # True = move on to next player
+            self._current_player = self._next_player()
+
+        if self._start_next_round():
+            self._on_after_round()
+            self.current_round += 1  # already increment here b.c. _does_game_proceed might rely on it
+
+        done = not self._does_game_proceed()
+        if done:
+            self._on_after_game()
+            self.info["episode_score"] = self.compute_episode_score()
+        elif self._start_next_round():  # prepare next round only when game has not ended yet
+            self.__prepare_next_round()
+
+        info = deepcopy(self.info)
+        self.info = {}  # reset info after each step
+        return done, info
+
+    def _should_pass_turn(self):
+        """
+        Whether to pass the turn to the next player. Otherwise, the current player keeps playing based on the context
+        set via set_player_context(player, content).
+        As every response request entails a single turn, this should return False if the player is to be reprompted.
+        """
+        return True
+
+    def _next_player(self) -> Player:
+        """
+        Subclasses can overwrite this method to determine the next player after a player's turn has been passed.
+
+        Default: The gamer master passes the turn to the next player in the player list (order as added).
+        Starting again with the first player, when all players have had their turn(s).
+
+        :return: the next (current) player
+        """
+        self._current_player_idx = (self._current_player_idx + 1) % len(self.players_by_names)
+        return self.get_players()[self._current_player_idx]
+
+    def _start_next_round(self) -> bool:
+        """
+        Subclasses can overwrite this method to specify when a next round should start after a player's turn is passed.
+
+        Default: Start next round when we cycled through the whole list i.e. it is again the first player's turn.
+
+        :return: True, when to start a new round
+        """
+        return self._current_player_idx == 0
+
+    def __prepare_next_round(self):
+        self.log_next_round()  # add record entry for player turns
+        self._on_before_round()
+
+    def get_response_feedback(self, response: str, context: Dict):
+        """
+        Optional.
+        :param response: The response of the current player.
+        :param context: The context given to the current player to generate the response for.
+        :return: a verbal feedback about the player's response given the context
+        """
+        return None
+
+    def compute_response_score(self, response: str, context: Dict):
+        """
+        Mandatory.
+        :param response: The response of the current player.
+        :param context: The context given to the current player to generate the response for.
+        :return: the performance score for a player's response given the context
+        """
+        return 0
+
+    def compute_episode_score(self):
+        """
+        :return: the performance of the agent over the whole episode
+        """
+        return 0
+
+    @abc.abstractmethod
+    def _on_valid_player_response(self, player: Player, parsed_response: str):
+        """
+        Method executed after a player response has been parsed and validated.
+
+        Set the response as the context for the other player (if necessary).
+
+        You could also set a new context for the current player and give the player
+        another turn by letting _should_pass_turn() return False.
+
+        To do this use the method set_context_for(player, response).
+        Args:
+            player: The Player instance that produced the response (or has been modified by the GM).
+            parsed_response: The parsed and valid response of the current player.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _validate_player_response(self, player: Player, response: str) -> bool:
+        """
+        Decide if a player response is valid. An invalid response breaks the game rules and might end the game.
+
+        Note: If the response is not valid, then _parse_response() and on_valid_player_response() will not be called.
+
+        However, game developers can decide to give the player another turn by letting _should_pass_turn() return False.
+
+        Args:
+            player: The player that gave the response.
+            response: The response of the current player.
+        Returns:
+            True, if the response is fine. Otherwise, False.
+        """
+        pass
+
+    def _parse_response(self, player: Player, response: str) -> str:
+        """Decide if a response utterance should be modified and apply modifications.
+
+        Hook: Modify this method for game-specific functionality.
+
+        Args:
+            player: The Player instance that produced the response. Intended to allow for individual handling of
+                different players.
+            response: The response of the current player.
+        Returns:
+            The parsed response
+        """
+        return response
+
+    @abc.abstractmethod
+    def _does_game_proceed(self) -> bool:
+        """Check if game should proceed.
+
+        Mandatory override.
+
+        This method is used to determine if a game should continue or be stopped. Both successful completion of the game
+        and game-ending failures should lead to this method returning False.
+        Returns:
+            A bool, True if game continues, False if game should stop.
+        """
+        pass
+
+    def _on_before_round(self):
+        """Executed in the play loop before a new round of gameplay starts.
+
+        Hook: Modify this method for game-specific functionality.
+        """
+        pass
+
+    def _on_after_round(self):
+        """Executed in the play loop after a round of gameply finished i.e. _start_next_round() resolves to True.
+
+        Hook: Modify this method for game-specific functionality.
+        """
+        pass
+
+    def _on_before_game(self):
+        """Executed once at the start, before entering the play loop.
+
+        Hook: Modify this method for game-specific functionality.
+
+        Adding the initial prompt to the dialogue history with this method is recommended.
+        """
+        pass
+
+    def _on_after_game(self):
+        """Executed once at the end, after exiting the play loop.
+
+        Hook: Modify this method for game-specific functionality.
+
+        This method is useful to process and log/record overall game results.
+        """
+        pass

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -91,6 +91,7 @@ class DialogueGameMaster(GameMaster):
             kwargs: Keyword arguments used to set up the GameMaster instance. This is usually a game instance object
                 read from the game's instances.json.
         """
+        self.game_recorder.auto_count_logging = False  # legacy games usually count and store themselves
         self._on_setup(**kwargs)
         self._current_player = self.get_players()[self._current_player_idx]
         self._on_before_game()

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -111,9 +111,6 @@ class DialogueGameMaster(GameMaster):
     def get_game_state(self):
         return None
 
-    def get_current_player(self) -> Player:
-        return self.current_player
-
     def set_context_for(self, player: Player, content: str, **extras):
         """
         Set the context for the specified Player. The player will be prompted with the context on its next turn.

--- a/clemcore/clemgame/legacy/scorer.py
+++ b/clemcore/clemgame/legacy/scorer.py
@@ -1,0 +1,178 @@
+"""
+Definition of metrics/scores that should be defined and logged for all games.
+This constants should be used so that the naming is standardised across games.
+
+Important: If the game is aborted, all episode-level scores must be set to numpy.nan
+and turn-level scores can be computed for the valid turns before the abortion action.
+"""
+import logging
+from pathlib import Path
+from typing import Dict, Union, Any, List
+
+from clemcore.clemgame.metrics import METRIC_REQUEST_COUNT, METRIC_REQUEST_COUNT_PARSED, METRIC_REQUEST_COUNT_VIOLATED, \
+    METRIC_REQUEST_SUCCESS_RATIO, METRIC_ABORTED, METRIC_LOSE, METRIC_SUCCESS
+from clemcore.clemgame.resources import store_file
+
+module_logger = logging.getLogger(__name__)
+
+KEY_META = "meta"
+KEY_PLAYERS = "players"
+KEY_TURN_SCORES = "turn scores"
+KEY_EPISODE_SCORES = "episode scores"
+
+
+class GameScorer:
+    """Calculates scores based on interaction logs. The resulting scores.json is structured like, for example:
+
+    {
+      "turn scores": {
+        "0": { # here come your metrics
+          "Accuracy": 0, # exemplary game specific metric
+          "Violated Request Count": 0, # framework metric
+          "Parsed Request Count": 1, # framework metric
+          "Request Count": 1 # framework metric
+        },
+        ...
+      "episode scores": {
+        "Violated Request Count": 0, # framework metric
+        "Parsed Request Count": 3, # framework metric
+        "Request Count": 3, # framework metric
+        "Request Success Ratio": 1.0, # framework metric
+        "Aborted": 0, # framework metric
+        "Success": 0, # framework metric
+        "Lose": 1, # framework metric
+        "Main Score": 0, # exemplary game specific metric
+        "Repetition-Guesser": 0, # exemplary game specific metric
+        "Repetition-Describer": 0 # exemplary game specific metric
+      }
+    }
+    """
+
+    def __init__(self, name: str, experiment: Dict, game_instance: Dict):
+        """
+        Args:
+            name: The name of the game.
+            experiment: The experiment to score.
+            game_instance: The game instance to score.
+        """
+        self.game_name = name
+        self.experiment = experiment
+        self.game_instance = game_instance
+        """ Stores values of score computation """
+        self.scores = {
+            KEY_META: {},
+            KEY_PLAYERS: {},
+            KEY_TURN_SCORES: {},
+            KEY_EPISODE_SCORES: {},
+        }
+
+    def store_scores(self, interactions_dir: Union[str, Path]):
+        """Store calculated scores to scores.json file.
+        Args:
+            interactions_dir: The game's record directory path.
+        """
+        store_file(self.scores, "scores.json", interactions_dir)
+
+    def log_turn_score(self, turn_idx: int, score_name: str, score_value: Any):
+        """Helper method to record a round (former 'turn') score/metric.
+        Args:
+            turn_idx: The index for the round the score is to be recorded for.
+            score_name: The name of the turn-level score/metric to record.
+            score_value: The value to be recorded for the turn-level score/metric for this turn.
+        """
+        if isinstance(score_value, bool):
+            module_logger.warning(f"{self.game_name}: Score {score_name} value is boolean, this can break the eval!")
+        if turn_idx not in self.scores[KEY_TURN_SCORES]:
+            self.scores[KEY_TURN_SCORES][turn_idx] = {}
+        if score_name in self.scores[KEY_TURN_SCORES][turn_idx]:
+            module_logger.warning(f"{self.game_name}: Score {score_name} overwritten at turn {turn_idx}!")
+        self.scores[KEY_TURN_SCORES][turn_idx][score_name] = score_value
+        module_logger.info(f"{self.game_name}: Logged turn {turn_idx} score {score_name}={score_value}.")
+
+    def log_episode_score(self, score_name, score_value):
+        """Helper method to record an episode-level score/metric for the whole episode.
+        Args:
+            score_name: The name of the episode-level score/metric to record.
+            score_value: The value to be recorded for the episode-level score/metric.
+        """
+        if score_name in self.scores[KEY_EPISODE_SCORES]:
+            module_logger.warning(f"{self.game_name}: Episode score {score_name} overwritten!")
+        self.scores[KEY_EPISODE_SCORES][score_name] = score_value
+        module_logger.info(f"{self.game_name}: Logged episode score {score_name}={score_value}.")
+
+    def compute_scores(self, interactions: Dict) -> None:
+        """Compute and log scores for a game episode. This method is used to perform complete scoring of an episode.
+        Args:
+            interactions: Dict containing the episode's interactions recorded during a benchmark run.
+        """
+        if KEY_META in interactions:  # if given, copy over meta info
+            self.scores[KEY_META] = interactions[KEY_META]
+        if "player_models" in interactions:  # if given, copy over players info
+            self.scores["player_models"] = interactions["player_models"]
+        if KEY_PLAYERS in interactions:  # if given, copy over players info
+            self.scores[KEY_PLAYERS] = interactions[KEY_PLAYERS]
+        self.score_turns(interactions)
+        self.score_game(interactions)
+
+    def score_turns(self, interactions: Dict) -> None:
+        """Iterate over episode turns, calculate and log turn-level scores.
+        Args:
+            interactions: Dict containing the episode's actions recorded during a benchmark run.
+        """
+        raise NotImplementedError()
+
+    def score_game(self, episode_interactions: Dict) -> None:
+        """Calculate and record standard clembench metric scores for an episode.
+        Args:
+            episode_interactions: Dict containing the episode's interactions. This contains the actions recorded during
+                a benchmark run.
+        """
+        self.score_game_end(episode_interactions)
+        self.score_requests(episode_interactions)
+        self.log_main_score(episode_interactions)
+
+    def score_game_end(self, episode_interactions: Dict) -> None:
+        """Calculate and record the ABORTED, LOSE and SUCCESS standard clembench metric scores.
+        Convenience method to cover mandatory clembench metric scores, so their calculation does not need to be
+        implemented anew for each new clemgame.
+        Args:
+            episode_interactions: Dict containing the episode's interactions. This contains the actions recorded during
+                a benchmark run.
+        """
+        aborted = int(episode_interactions[METRIC_ABORTED])
+        lose = int(episode_interactions[METRIC_LOSE]) if not aborted else 0
+        success = 1 - lose if not aborted else 0
+
+        self.log_episode_score(METRIC_ABORTED, aborted)
+        self.log_episode_score(METRIC_LOSE, lose)
+        self.log_episode_score(METRIC_SUCCESS, success)
+
+    def score_requests(self, episode_interactions: Dict):
+        """Calculate and record standard request-based clembench metric scores.
+        Records total request count, parsed, violated, and success ratio of parsed requests over all requests in an
+        episode.
+        Convenience method to cover mandatory clembench metric scores, so their calculation does not need to be
+        implemented anew for each new clemgame.
+        Args:
+            episode_interactions: Dict containing the episode's interactions. This contains the actions recorded during
+                a benchmark run.
+        """
+        request_count = episode_interactions[
+            METRIC_REQUEST_COUNT]  # could also be calculated by adding parsed and violated requests
+        parsed_requests = episode_interactions[METRIC_REQUEST_COUNT_PARSED]
+        violated_requests = episode_interactions[METRIC_REQUEST_COUNT_VIOLATED]
+
+        self.log_episode_score(METRIC_REQUEST_COUNT, request_count)
+        self.log_episode_score(METRIC_REQUEST_COUNT_PARSED, parsed_requests)
+        self.log_episode_score(METRIC_REQUEST_COUNT_VIOLATED, violated_requests)
+        self.log_episode_score(METRIC_REQUEST_SUCCESS_RATIO, parsed_requests / request_count)
+
+    def log_main_score(self, episode_interactions: Dict):
+        """Record the game's main score.
+        Replace this method with a method that calculates and logs the clemgame's main score aka BENCH_SCORE.
+        Must be implemented! Recording BENCH_SCORE is mandatory.
+        Args:
+            episode_interactions: Dict containing the episode's interactions. This contains the actions recorded during
+                a benchmark run.
+        """
+        raise NotImplementedError()

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -235,10 +235,10 @@ class DialogueGameMaster(GameMaster):
         while not done:
             context = self.get_context_for(self.current_player)
             response = self.current_player(context)
-            done, _ = self.process_turn(response)
+            done, _ = self.step(response)
 
     @final
-    def process_turn(self, response: str) -> Tuple[bool, Dict]:
+    def step(self, response: str) -> Tuple[bool, Dict]:
         """
         Verifies the response and transitions the game by applying the current player's response for the turn.
 

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -21,17 +21,19 @@ class ResponseError(Exception):
     General error class for problems with the player response.
 
     Developers can introduce more specific error types by subclassing this error.
-    Alternatively, the 'reason' attribute can be used to define more granular error types.
+    Alternatively, the 'key' attribute can be used to define more granular error types.
     """
 
-    def __init__(self, reason: str = None, response: str = None):
+    def __init__(self, reason: Optional[str] = None, response: Optional[str] = None, key: Optional[str] = None):
         """
         :param reason: (optional) a brief description of the cause
         :param response: (optional) the player's response
+        :param key: (optional) a key word
         """
         super().__init__(reason)
         self.reason = reason
         self.response = response
+        self.key = key
 
     def __str__(self):
         return f"{self.__class__.__name__}: {self.reason}"
@@ -138,7 +140,7 @@ class GameMaster(abc.ABC):
     @abc.abstractmethod
     def setup(self, **kwargs):
         """Load resources and prepare everything to play the game.
-        Needs to log the players dictionary via self.log_players(players_dict).
+        Needs to log the player infos via self.log_player().
         Called by the game's GameBenchmark run method for each game instance.
         Args:
             kwargs: Keyword arguments used to set up the GameMaster instance.
@@ -348,7 +350,7 @@ class DialogueGameMaster(GameMaster):
         Default: The gamer master passes the turn to the next player in the player list (order as added).
         Starting again with the first player, when all players have had their turn(s).
 
-        :return: the new current player
+        :return: the next (current) player
         """
         self._current_player_idx = (self._current_player_idx + 1) % len(self.players_by_names)
         return self.get_players()[self._current_player_idx]
@@ -359,15 +361,11 @@ class DialogueGameMaster(GameMaster):
 
         Default: Start next round when we cycled through the whole list i.e. it is again the first player's turn.
 
-        :return: True, when it's the first player's turn to start a new round
+        :return: True, when to start a new round
         """
         return self._current_player_idx == 0
 
     def __prepare_next_round(self):
-        """
-        Logs moving to next round and calls self._on_before_round().
-        Do not override.
-        """
         self.log_next_round()  # add record entry for player turns
         self._on_before_round()
 

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Tuple, Any, Union, final, Optional
 
 from clemcore import backends
 from clemcore.clemgame.environment import Action, GameEnvironment
+from clemcore.clemgame.errors import ParseError, GameError
 from clemcore.clemgame.registry import GameSpec
 from clemcore.clemgame.player import Player
 from clemcore.clemgame.recorder import NoopGameRecorder
@@ -14,66 +15,6 @@ from clemcore.clemgame.resources import GameResourceLocator
 from clemcore.utils.string_utils import to_pretty_json
 
 module_logger = logging.getLogger(__name__)
-
-
-class ResponseError(Exception):
-    """
-    General error class for problems with the player response.
-
-    Developers can introduce more specific error types by subclassing this error.
-    Alternatively, the 'key' attribute can be used to define more granular error types.
-    """
-
-    def __init__(self, reason: Optional[str] = None, response: Optional[str] = None, key: Optional[str] = None):
-        """
-        :param reason: (optional) a brief description of the cause
-        :param response: (optional) the player's response
-        :param key: (optional) a key word
-        """
-        super().__init__(reason)
-        self.reason = reason
-        self.response = response
-        self.key = key
-
-    def __str__(self):
-        return f"{self.__class__.__name__}: {self.reason}"
-
-
-class ProtocolError(ResponseError):
-    """Raised when a message does not follow the communication protocol expected by the game master."""
-    pass
-
-
-class ParseError(ProtocolError):
-    """
-    This error is supposed to be raised when player messages cannot be parsed or understood by the game master e.g.
-    because the response does not start with a specified prefix.
-
-    For example:
-        - taboo: clue giver messages should start with 'CLUE:'
-        - wordle: guesser messages should start with 'GUESS:'
-    """
-    pass
-
-
-class GameError(ResponseError):
-    """Raised when a verbal action of a player causes problems for advancing the game."""
-    pass
-
-
-class RuleViolationError(GameError):
-    """Raised when a verbal action of a player violates the specified game rules.
-
-    For example:
-        - taboo: mentioning the target word as the clue giver
-        - wordle: guessing words that are not exactly 5 letters long
-    """
-    pass
-
-
-class NotApplicableError(GameError):
-    """Raised when a verbal action of a player cannot be applied to advance the game state."""
-    pass
 
 
 class GameMaster(abc.ABC):
@@ -487,11 +428,11 @@ class EnvGameMaster(GameMaster):
     """Extended GameMaster, integrating a GameEnvironment as self-contained object for state management."""
 
     def __init__(
-        self,
-        game_spec: GameSpec,
-        experiment: dict,
-        player_models: List[backends.Model],
-        game_environment: GameEnvironment,
+            self,
+            game_spec: GameSpec,
+            experiment: dict,
+            player_models: List[backends.Model],
+            game_environment: GameEnvironment,
     ):
         """
         Args:
@@ -552,7 +493,7 @@ class EnvGameMaster(GameMaster):
                 read from the game's instances.json.
         """
         self._on_setup(**kwargs)
-        if self.players_by_names: # todo: why should this be empty here?
+        if self.players_by_names:  # todo: why should this be empty here?
             self.current_player = self.get_players()[self.current_player_idx]
 
     @abc.abstractmethod

--- a/clemcore/clemgame/metrics.py
+++ b/clemcore/clemgame/metrics.py
@@ -174,7 +174,7 @@ class GameScorer:
 
     @final
     def log_episode_score(self, score_name, score_value):
-        """Helper method to tecord an episode-level score/metric for the whole episode.
+        """Helper method to record an episode-level score/metric for the whole episode.
         Args:
             score_name: The name of the episode-level score/metric to record.
             score_value: The value to be recorded for the episode-level score/metric.

--- a/clemcore/clemgame/recorder.py
+++ b/clemcore/clemgame/recorder.py
@@ -79,6 +79,7 @@ class NoopGameRecorder(GameRecorder):
     def __init__(self):
         self.interactions = []
         self.requests = []
+        self.auto_count_logging = False  # see DefaultGameRecorder
 
     def log_next_round(self):
         pass
@@ -127,6 +128,9 @@ class DefaultGameRecorder(GameRecorder):
         self.requests_counts = [0]  # count per round (initially zero)
         self.violated_requests_counts = [0]  # count per round (initially zero)
         self.successful_requests_counts = [0]  # count per round (initially zero)
+        # For legacy games, the counts were logged by the games.
+        # New games can rely on the count logging by the recorder.
+        self.auto_count_logging = True
 
     def log_next_round(self):
         """Call this method to group interactions per turn."""
@@ -232,9 +236,10 @@ class DefaultGameRecorder(GameRecorder):
             module_logger.warning(f"No calls logged!")
 
         # add default framework metrics
-        self.log_key(METRIC_REQUEST_COUNT, self.requests_counts)
-        self.log_key(METRIC_REQUEST_COUNT_VIOLATED, self.violated_requests_counts)
-        self.log_key(METRIC_REQUEST_COUNT_PARSED, self.successful_requests_counts)
+        if self.auto_count_logging:
+            self.log_key(METRIC_REQUEST_COUNT, self.requests_counts)
+            self.log_key(METRIC_REQUEST_COUNT_VIOLATED, self.violated_requests_counts)
+            self.log_key(METRIC_REQUEST_COUNT_PARSED, self.successful_requests_counts)
 
         store_results_file(self._game_name, self.interactions,
                            "interactions.json",

--- a/clemcore/clemgame/registry.py
+++ b/clemcore/clemgame/registry.py
@@ -1,4 +1,4 @@
-import collections
+import copy
 import json
 import os.path
 from typing import List, Dict, Union
@@ -26,6 +26,14 @@ class GameSpec(SimpleNamespace):
                 raise KeyError(f"No game path specified in {kwargs}")
             if "players" not in self:
                 raise KeyError(f"No players specified in {kwargs}")
+
+    def __deepcopy__(self, memo):
+        # Create a new blank instance without triggering __init__ which will lead to KeyErrors
+        _copy = type(self).__new__(self.__class__)
+        memo[id(self)] = _copy
+        for k, v in self.__dict__.items():
+            setattr(_copy, k, copy.deepcopy(v, memo))
+        return _copy
 
     def __repr__(self):
         """Returns string representation of this GameSpec."""


### PR DESCRIPTION
**Playpen**
- implement deepcopy for `GameSpec` to allow playpen branching env
- rename `process_turn()` back to `step()` in favour of playpen compatibility and RL-focus
- remove `get_current_player()` in favor of `current_player` property in legacy DGM

**Legacy Clembench Games**
- introduce legacy module with DGM and Scorer
- add toggle to disable count logging in recorder (could overwrite game logs)
- introduce errors module and expose all error types
- add `key` arg to `ResponseError`; improve docs for easier compare with legacy

NOTE: This update marks the end of life of the `maintenance/2.x` branch!