### PR TITLE
Store image state representations in results folder and display image states in transcript.html

### DIFF
--- a/clemcore/clemgame/benchmark.py
+++ b/clemcore/clemgame/benchmark.py
@@ -194,8 +194,8 @@ class GameBenchmark(GameResourceLocator):
             experiment_config["player_models"] = player_models_infos
 
             experiment_record_dir = f"{experiment_idx}_{experiment_name}"
-            store_json(experiment_config, "experiment.json",
-                       os.path.join(results_dir, player_models_folder, self.game_name, experiment_record_dir))
+            experiment_record_path = os.path.join(results_dir, player_models_folder, self.game_name, experiment_record_dir)
+            store_json(experiment_config, "experiment.json", experiment_record_path)
 
             episode_counter = 0
             error_count = 0
@@ -219,7 +219,8 @@ class GameBenchmark(GameResourceLocator):
                                                     experiment_name,  # meta info for transcribe
                                                     task_id,  # meta info for transcribe
                                                     player_models_folder,  # meta info for transcribe
-                                                    player_models_infos)
+                                                    episode_dir, #  meta info for transcribe
+                                                    player_models_infos)  # meta info for transcribe
                 try:
                     game_master = self.create_game_master(experiment_config, player_models)
                     game_master.game_recorder = game_recorder


### PR DESCRIPTION
This PR proposes to merge the transcript updates, as discussed on Mattermost.

In the new implementation, in `build_transcript`, the `image` key that stores the image paths is accessed as directly part of the `action` dict. Previously, it was part of the `content` dict that was inside the `action` dict. `image_list` is then created to carry the image sources. Solution should be backwards-compatible.

Furthermore, in `build_transcript`, a new if-branch is added to check if the image source starts with `/results` (which is the case in the new implementation), which then makes the image path relative to the transcript (such that it can successfully be displayed in the `transcript.html`).

Last but not least, the GameRecorder is expanded to include a `store_image` method that will be used by the GameEnvironment (GameEnvironment changes are not included in this PR — they will be part of the larger PR I'm currently preparing). This method will store the images per turn in the associated `images` folder that is inside the episode directory.

