### PR TITLE
Decouple GameInstanceIterator from GameBenchmark

### DIFF
--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -33,27 +33,19 @@ class GameInstanceIterator:
         instances: The instances dict with experiments and game instances.
         sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
             If a mapping returns None, then all game instances will be used.
-        do_shuffle: Whether to shuffle the instances on each reset.
-        reset: Whether to reset the iterator on init, so that it becomes directly usable.
     """
 
     def __init__(self,
                  game_name: str,
                  instances: Dict,
                  *,
-                 sub_selector: Optional[Callable[[str, str], List[int]]] = None,
-                 do_shuffle: bool = False,
-                 reset: bool = True
-                 ):
+                 sub_selector: Optional[Callable[[str, str], List[int]]] = None):
         assert game_name is not None, "Game name must be given"
-        self._game_name = game_name
         assert instances is not None, "Instances must be given"
+        self._game_name = game_name
         self._instances: Dict = instances
         self._sub_selector: Optional[Callable[[str, str], List[int]]] = sub_selector
-        self._do_shuffle: bool = do_shuffle
         self._queue = []
-        if reset:
-            self.reset()
 
     def __iter__(self):
         return self
@@ -70,7 +62,6 @@ class GameInstanceIterator:
     def __deepcopy__(self) -> "GameInstanceIterator":
         _copy = type(self).__new__(self.__class__)
         _copy._instance = self._instances
-        _copy._do_shuffle = self._do_shuffle
         _copy._queue = copy(self._queue)  # no need to copy the underlying instances
         return _copy
 
@@ -104,71 +95,53 @@ class GameInstanceIterator:
         if verbose:
             stdout_logger.info("Prepared instance queue for %s using %s experiments %s and %s instances in total.",
                                self._game_name, len(experiment_names), experiment_names, num_instances)
-        if self._do_shuffle:
-            random.shuffle(self._queue)
         return self
 
     @classmethod
-    def from_game_spec(
-            cls,
-            game_spec: GameSpec,
-            *,
-            sub_selector: Optional[Callable[[str, str], List[int]]] = None,
-            do_shuffle: bool = False,
-            do_reset: bool = False
-    ):
+    def from_game_spec(cls,
+                       game_spec: GameSpec,
+                       *,
+                       sub_selector: Optional[Callable[[str, str], List[int]]] = None):
         """Load a game instance iterator using information from the given game spec.
 
         Args:
             game_spec: The game spec with a game path and instance file name.
             sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
                 If a mapping returns None, then all game instances will be used.
-            do_shuffle: Whether to shuffle the order of the instances on each reset. Default: False.
-            do_reset: Whether to initially reset the instance iterator. Default: False.
         """
-        file_path = os.path.join(game_spec.game_path, "in", game_spec.instances)
         return cls.from_file(
             game_spec.game_name,
-            file_path,
-            sub_selector=sub_selector,
-            do_shuffle=do_shuffle,
-            do_reset=do_reset
+            os.path.join(game_spec.game_path, "in"),
+            game_spec.instances,
+            sub_selector=sub_selector
         )
 
     @classmethod
     def from_file(cls,
                   game_name: str,
-                  file_path: str,
+                  instance_dir_path: str,
+                  instance_file_name: str,
                   *,
-                  sub_selector: Optional[Callable[[str, str], List[int]]] = None,
-                  do_shuffle: bool = False,
-                  do_reset: bool = False):
+                  sub_selector: Optional[Callable[[str, str], List[int]]] = None):
         """Load a game instance iterator using the given file path.
 
         Args:
             game_name: The name of the game to which the instances belong to. Necessary for the sub_selector to work.
-            file_path: The path to a JSON file containing the game instances.
+            instance_dir_path: The path the directory containing a JSON file with the game instances.
+            instance_file_name: The name of the instance file to load.
             sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
                 If a mapping returns None, then all game instances will be used.
-            do_shuffle: Whether to shuffle the order of the instances on each reset. Default: False.
-            do_reset: Whether to initially reset the instance iterator. Default: False.
         """
-        filename = os.path.basename(file_path)
+        file_path = os.path.join(instance_dir_path, instance_file_name)
         instances = load_json(file_path)
         if "experiments" not in instances:
-            raise ValueError(f"{game_name}: No 'experiments' key in {filename}")
+            raise ValueError(f"{game_name}: No 'experiments' key in {instance_file_name}")
         experiments = instances["experiments"]
         if not isinstance(experiments, list):
-            raise ValueError(f"{game_name}: Experiments in {filename} is not a list")
+            raise ValueError(f"{game_name}: Experiments in {instance_file_name} is not a list")
         if len(experiments) == 0:
-            raise ValueError(f"{game_name}: Experiments list in {filename} is empty")
-        return cls(
-            game_name,
-            instances,
-            sub_selector=sub_selector,
-            do_shuffle=do_shuffle,
-            reset=do_reset
-        )
+            raise ValueError(f"{game_name}: Experiments list in {instance_file_name} is empty")
+        return cls(game_name, instances, sub_selector=sub_selector)
 
 
 class GameInstanceGenerator(GameResourceLocator):

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -109,6 +109,8 @@ class GameInstanceIterator:
             sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
                 If a mapping returns None, then all game instances will be used.
         """
+        if not hasattr(game_spec, "instances"):
+            game_spec.instances = "instances"  # if not already set, fallback to default file name
         return cls.from_file(
             game_spec.game_name,
             os.path.join(game_spec.game_path, "in"),
@@ -120,7 +122,7 @@ class GameInstanceIterator:
     def from_file(cls,
                   game_name: str,
                   instance_dir_path: str,
-                  instance_file_name: str,
+                  instance_file_name: str = "instances",
                   *,
                   sub_selector: Optional[Callable[[str, str], List[int]]] = None):
         """Load a game instance iterator using the given file path.

--- a/clemcore/clemgame/registry.py
+++ b/clemcore/clemgame/registry.py
@@ -5,12 +5,12 @@ from typing import List, Dict, Union
 from types import SimpleNamespace
 import logging
 import nltk
-import clemcore.utils.file_utils as file_utils
 
 logger = logging.getLogger(__name__)
 stdout_logger = logging.getLogger("clemcore.cli")
 
 ENV_CLEMBENCH_HOME = "CLEMBENCH_HOME"
+
 
 class GameSpec(SimpleNamespace):
     """Base class for game specifications.

--- a/clemcore/clemgame/runners/__init__.py
+++ b/clemcore/clemgame/runners/__init__.py
@@ -1,0 +1,5 @@
+__all__ = [
+    "dispatch",
+    "batchwise",
+    "sequential"
+]

--- a/clemcore/clemgame/runners/sequential.py
+++ b/clemcore/clemgame/runners/sequential.py
@@ -4,20 +4,20 @@ from typing import List
 from tqdm import tqdm
 
 from clemcore.backends import Model
-from clemcore.clemgame import GameBenchmark, GameBenchmarkCallbackList
+from clemcore.clemgame import GameBenchmark, GameBenchmarkCallbackList, GameInstanceIterator
 
 module_logger = logging.getLogger(__name__)
 stdout_logger = logging.getLogger("clemcore.run")
 
 
 def run(game_benchmark: GameBenchmark,
+        game_instance_iterator: GameInstanceIterator,
         player_models: List[Model],
         *,
         callbacks: GameBenchmarkCallbackList):
     callbacks.on_benchmark_start(game_benchmark)
     error_count = 0
-    game_benchmark.game_instance_iterator.reset(verbose=True)  # set up the instance queue to iterate over
-    for experiment, game_instance in tqdm(game_benchmark.game_instance_iterator, desc="Playing game instances"):
+    for experiment, game_instance in tqdm(game_instance_iterator, desc="Playing game instances"):
         try:
             game_master = game_benchmark.create_game_master(experiment, player_models)
             callbacks.on_game_start(game_master, game_instance)

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -156,8 +156,6 @@ def run(game_selector: Union[str, Dict, GameSpec],
             # configure instance file to be used
             if instances_filename:
                 game_spec.instances = instances_filename  # force the use of cli argument, when given
-            if not hasattr(game_spec, "instances"):
-                game_spec.instances = "instances"  # set default, or use whatever is already set
 
             if experiment_name:  # establish experiment filter, if given
                 logger.info("Only running experiment: %s", experiment_name)

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Union, Callable, Optional
 import clemcore.backends as backends
 from clemcore.backends import ModelRegistry, BackendRegistry
 from clemcore.clemgame import GameRegistry, GameSpec, InstanceFileSaver, ExperimentFileSaver, \
-    InteractionsFileSaver, GameBenchmarkCallbackList, ImageFileSaver, RunFileSaver
+    InteractionsFileSaver, GameBenchmarkCallbackList, ImageFileSaver, RunFileSaver, GameInstanceIterator
 from clemcore.clemgame import benchmark
 from clemcore import clemeval, get_version
 from clemcore.clemgame.runners import dispatch
@@ -141,10 +141,24 @@ def run(game_selector: Union[str, Dict, GameSpec],
         player_models.append(model)
     logger.info("Loading models took: %s", datetime.now() - start)
 
+    # setup reusable callbacks here once
+    callbacks = GameBenchmarkCallbackList([
+        InstanceFileSaver(results_dir_path, player_models),
+        ExperimentFileSaver(results_dir_path, player_models),
+        InteractionsFileSaver(results_dir_path, player_models),
+        ImageFileSaver(results_dir_path, player_models),
+        RunFileSaver(results_dir_path, player_models)]
+    )
+
     all_start = datetime.now()
-    run_file_saver = RunFileSaver(results_dir_path, player_models)
     for game_spec in game_specs:
         try:
+            # configure instance file to be used
+            if instances_filename:
+                game_spec.instances = instances_filename  # force the use of cli argument, when given
+            if not hasattr(game_spec, "instances"):
+                game_spec.instances = "instances"  # set default, or use whatever is already set
+
             if experiment_name:  # establish experiment filter, if given
                 logger.info("Only running experiment: %s", experiment_name)
                 if sub_selector is None:
@@ -153,18 +167,18 @@ def run(game_selector: Union[str, Dict, GameSpec],
                     game_ids = sub_selector(game_spec.game_name, experiment_name)
                     sub_selector = partial(experiment_filter, selected_experiment=experiment_name, game_ids=game_ids)
 
-            with benchmark.load_from_spec(game_spec,
-                                          instances_filename=instances_filename,
-                                          sub_selector=sub_selector) as game_benchmark:
+            with benchmark.load_from_spec(game_spec) as game_benchmark:
                 time_start = datetime.now()
                 logger.info(f'Running {game_spec["game_name"]} (models={player_models})')
-                callbacks = GameBenchmarkCallbackList()
-                callbacks.append(InstanceFileSaver(results_dir_path, player_models))
-                callbacks.append(ExperimentFileSaver(results_dir_path, player_models))
-                callbacks.append(InteractionsFileSaver(results_dir_path, player_models))
-                callbacks.append(ImageFileSaver(results_dir_path, player_models))
-                callbacks.append(run_file_saver)
-                dispatch.run(game_benchmark, player_models, callbacks=callbacks, batch_size=batch_size)
+                game_instance_iterator = GameInstanceIterator.from_game_spec(game_spec, sub_selector=sub_selector)
+                game_instance_iterator.reset(verbose=True)
+                dispatch.run(
+                    game_benchmark,
+                    game_instance_iterator,
+                    player_models,
+                    callbacks=callbacks,
+                    batch_size=batch_size
+                )
                 logger.info(f"Running {game_spec['game_name']} took: %s", datetime.now() - time_start)
         except Exception as e:
             logger.exception(e)
@@ -187,7 +201,7 @@ def score(game_selector: Union[str, Dict, GameSpec], results_dir: str = None):
     for game_spec in game_specs:
         try:
             time_start = datetime.now()
-            with benchmark.load_from_spec(game_spec, do_setup=False) as game_benchmark:
+            with benchmark.load_from_spec(game_spec) as game_benchmark:
                 game_benchmark.compute_scores(results_dir)
             logger.info(f"Scoring {game_benchmark.game_name} took: %s", datetime.now() - time_start)
         except Exception as e:


### PR DESCRIPTION
For more flexibility when using runners, we decouple the instantiation of the `GameInstanceIterator` from the `GameBenchmark´. 

We now create the instance iterator in `cli.py` and pass it to the runner directly.

The runners by default only iterate once over the instances.