### PR TITLE
Update Dependency Versions

### DIFF
--- a/key.json.template
+++ b/key.json.template
@@ -18,7 +18,7 @@
   "slurk": {
     "api_key": "00000000-0000-0000-0000-000000000000",
     "host": "http://localhost:5000"
-  }
+  },
   "openai_compatible": {
     "api_key": "",
     "base_url": "http://127.0.0.1:8000/v1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ dependencies = [
     "retry>=0.9.2",
     "tqdm>=4.65.0",
     "nltk==3.8.1", # pin due to transformers==4.51.1 requires nltk<=3.8.1
-    "aleph-alpha-client==7.0.1",
-    "openai==1.75.0",
-    "anthropic==0.47.1",
-    "cohere==4.48",
-    "google-generativeai==0.8.4",
-    "mistralai==1.8.0",
+    "aleph-alpha-client==11.2.0",
+    "openai==1.99.9",
+    "anthropic==0.64.0",
+    "cohere==5.17",
+    "google-generativeai==0.8.5",
+    "mistralai==1.9.6",
     "matplotlib==3.7.1",
     "pandas==2.0.1",
     "seaborn==0.12.2",
@@ -38,20 +38,20 @@ dependencies = [
 [project.optional-dependencies]
 vllm = [
     "torch~=2.6.0",
-    "transformers==4.51.1",
+    "transformers==4.55.2", # keep in sync with huggingface extra
     "vllm==0.8.4" # requires: torch==2.6.0 transformers>=4.51.1 cuda==12.4 openai>=1.52.0
 ]
 huggingface = [
     "torch~=2.1.1",
-    "sentencepiece==0.1.99",
-    "accelerate==1.2.1",
-    "protobuf==4.21.6",
-    "einops==0.6.1",
-    "bitsandbytes==0.45.3",
-    "peft==0.15.2",
-    "transformers==4.51.1", # nltk<=3.8.1 torch>=2.0 sentencepiece>=0.1.91,!=0.1.92 accelerate>=0.26.0 protobuf
     "torchvision==0.16.1", # needs to be kept in synch with torch
-    "timm>=1.0.15"
+    "sentencepiece==0.2.1",
+    "accelerate==1.10.0",
+    "protobuf==6.32.0",
+    "einops==0.8.1",
+    "bitsandbytes==0.45.5", # "bitsandbytes==0.46.0" requires "torch>=2.2,<3"
+    "peft==0.17.0", # "torch>=1.13.0" "accelerate>=0.21.0"
+    "timm==1.0.19", # for transformers
+    "transformers==4.55.2", # nltk<=3.8.1 torch>=2.1 sentencepiece>=0.1.91,!=0.1.92 torch>=2.1 timm<=1.0.19
 ]
 slurk = [
     "python-engineio==4.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ vllm = [
 huggingface = [
     "torch~=2.1.1",
     "torchvision==0.16.1", # needs to be kept in synch with torch
-    "accelerate==1.10.0",
+    "accelerate==1.2.1",
     "bitsandbytes==0.45.5", # "bitsandbytes==0.46.0" requires "torch>=2.2,<3"
     "peft==0.17.0", # "torch>=1.13.0" "accelerate>=0.21.0"
     "timm>=1.0.15,<=1.0.19", # for transformers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,10 @@ vllm = [
 huggingface = [
     "torch~=2.1.1",
     "torchvision==0.16.1", # needs to be kept in synch with torch
-    "sentencepiece==0.2.1",
     "accelerate==1.10.0",
-    "protobuf==6.32.0",
-    "einops==0.8.1",
     "bitsandbytes==0.45.5", # "bitsandbytes==0.46.0" requires "torch>=2.2,<3"
     "peft==0.17.0", # "torch>=1.13.0" "accelerate>=0.21.0"
-    "timm==1.0.19", # for transformers
+    "timm==1.0.15", # for transformers
     "transformers==4.55.2", # nltk<=3.8.1 torch>=2.1 sentencepiece>=0.1.91,!=0.1.92 torch>=2.1 timm<=1.0.19
 ]
 slurk = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ huggingface = [
     "accelerate==1.10.0",
     "bitsandbytes==0.45.5", # "bitsandbytes==0.46.0" requires "torch>=2.2,<3"
     "peft==0.17.0", # "torch>=1.13.0" "accelerate>=0.21.0"
-    "timm==1.0.15", # for transformers
+    "timm>=1.0.15,<=1.0.19", # for transformers
     "transformers==4.55.2", # nltk<=3.8.1 torch>=2.1 sentencepiece>=0.1.91,!=0.1.92 torch>=2.1 timm<=1.0.19
 ]
 slurk = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ vllm = [
 huggingface = [
     "torch~=2.1.1",
     "torchvision==0.16.1", # needs to be kept in synch with torch
-    "accelerate==1.2.1",
+    "accelerate==1.2.1", # 1.10.0 causes trouble with pytorch<2.2 (No module named 'torch.distributed.device_mesh')
     "bitsandbytes==0.45.5", # "bitsandbytes==0.46.0" requires "torch>=2.2,<3"
     "peft==0.17.0", # "torch>=1.13.0" "accelerate>=0.21.0"
     "timm>=1.0.15,<=1.0.19", # for transformers

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,7 +1,38 @@
 import unittest
 
-from clemcore.backends import ModelRegistry, BackendRegistry
+from clemcore.backends import ModelRegistry, BackendRegistry, ModelSpec
+from clemcore.backends.anthropic_api import Anthropic
+from clemcore.backends.openai_api import OpenAI
 from clemcore.backends.utils import ensure_alternating_roles
+
+
+class GenerateTestCase(unittest.TestCase):
+
+    def _generate_response_test(self, backend, model_name, messages):
+        model_spec = ModelSpec.from_dict(dict(model_name=model_name, model_id=model_name, model_config={}))
+        model = backend.get_model_for(model_spec)
+        model.set_gen_arg("temperature", 0)
+        model.set_gen_arg("max_tokens", 100)
+        prompt, response, response_text = model.generate_response(messages)
+        assert prompt is not None
+        print(prompt)
+        assert response is not None
+        assert response_text is not None
+        print(response_text)
+
+    def test_generate_response_with_openai(self):
+        self._generate_response_test(
+            OpenAI(),
+            "gpt-4o-mini-2024-07-18",
+            [{"role": "user", "content": "How are you?"}]
+        )
+
+    def test_generate_response_with_anthropic(self):
+        self._generate_response_test(
+            Anthropic(),
+            "claude-3-haiku-20240307",
+            [{"role": "user", "content": "How are you?"}]
+        )
 
 
 class UtilsTestCase(unittest.TestCase):


### PR DESCRIPTION
Before the next benchmark run we want to update dependencies, especially, transformers to 4.55.