### PR TITLE
clemcore/backends/cohere -> Line 84, response.pop will now pop the cl…

### DIFF
--- a/clemcore/backends/cohere_api.py
+++ b/clemcore/backends/cohere_api.py
@@ -81,7 +81,8 @@ class CohereModel(backends.Model):
         prompt = json.dumps({"message": message, "chat_history": chat_history})
 
         response = output.__dict__
-        response.pop('client')
-        response.pop('token_count')
+        # This fix is removing the 'client' key, only when it is available.
+        response.pop('client', None)
+        response.pop('token_count', None)
 
         return prompt, response, response_text


### PR DESCRIPTION
This fix is removing the 'client' key, only when it is available.

```
response.pop('client', None)
response.pop('token_count', None)
```