### PR TITLE
Update backend API clients and dependencies

### DIFF
--- a/clemcore/backends/anthropic_api.py
+++ b/clemcore/backends/anthropic_api.py
@@ -122,7 +122,7 @@ class AnthropicModel(backends.Model):
                 encoded_messages.append(claude_message)
         return encoded_messages, system_message
 
-    @retry(tries=3, delay=0, logger=logger)
+    @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
     def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:

--- a/clemcore/backends/anthropic_api.py
+++ b/clemcore/backends/anthropic_api.py
@@ -164,6 +164,8 @@ class AnthropicModel(backends.Model):
             gen_kwargs["max_tokens"] = 4000 + self.max_tokens # todo: we need to use self.gen_args for this
             gen_kwargs["thinking"] = {"type": "enabled", "budget_tokens": 4000}
         completion = self.client.messages.create(**gen_kwargs)
+        if completion.role != "assistant":  # safety check
+            raise AttributeError("Response message role is " + completion.role + " but should be 'assistant'")
         response_text = completion.content[content_index].text
         response = completion.model_dump(mode="json")
         return prompt, response, response_text

--- a/clemcore/backends/anthropic_api.py
+++ b/clemcore/backends/anthropic_api.py
@@ -17,7 +17,7 @@ class Anthropic(backends.RemoteBackend):
     """Backend class for accessing the Anthropic remote API."""
 
     def _make_api_client(self):
-        self.client = anthropic.Anthropic(api_key=self.key["api_key"])
+        return anthropic.Anthropic(api_key=self.key["api_key"])
 
     def get_model_for(self, model_spec: backends.ModelSpec) -> backends.Model:
         """Get an Anthropic model instance based on a model specification.

--- a/clemcore/backends/anthropic_api.py
+++ b/clemcore/backends/anthropic_api.py
@@ -32,7 +32,7 @@ class Anthropic(backends.RemoteBackend):
 class AnthropicModel(backends.Model):
     """Model class accessing the Anthropic remote API."""
 
-    def __init__(self, client: anthropic.Client, model_spec: backends.ModelSpec):
+    def __init__(self, client: anthropic.Anthropic, model_spec: backends.ModelSpec):
         """
         Args:
             client: An Anthropic library Client class.
@@ -77,7 +77,6 @@ class AnthropicModel(backends.Model):
             if message["role"] == "system":
                 system_message = message["content"]
             else:
-
                 content = list()
                 content.append({
                     "type": "text",
@@ -86,19 +85,18 @@ class AnthropicModel(backends.Model):
 
                 if "image" in message.keys() and 'multimodality' not in self.model_spec.model_config:
                     logger.info(
-                        f"The backend {self.model_spec.__getattribute__('model_id')} does not support multimodal inputs!")
+                        f"The backend {self.model_spec.model_id} does not support multimodal inputs!")
                     raise Exception(
-                        f"The backend {self.model_spec.__getattribute__('model_id')} does not support multimodal inputs!")
-
+                        f"The backend {self.model_spec.model_id} does not support multimodal inputs!")
                 if 'multimodality' in self.model_spec.model_config:
                     if "image" in message.keys():
 
-                        if not self.model_spec['model_config']['multimodality']['multiple_images'] and len(
+                        if not self.model_spec.model_config['multimodality']['multiple_images'] and len(
                                 message['image']) > 1:
                             logger.info(
-                                f"The backend {self.model_spec.__getattribute__('model_id')} does not support multiple images!")
+                                f"The backend {self.model_spec.model_id} does not support multiple images!")
                             raise Exception(
-                                f"The backend {self.model_spec.__getattribute__('model_id')} does not support multiple images!")
+                                f"The backend {self.model_spec.model_id} does not support multiple images!")
                         else:
                             # encode each image
                             for image in message['image']:
@@ -117,19 +115,17 @@ class AnthropicModel(backends.Model):
                                         "data": encoded_image_data,
                                     }
                                 })
-
                 claude_message = {
                     "role": message["role"],
                     "content": content
                 }
                 encoded_messages.append(claude_message)
-
         return encoded_messages, system_message
 
     @retry(tries=3, delay=0, logger=logger)
     @augment_response_object
     @ensure_messages_format
-    def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:
+    def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:
         """Request a generated response from the Anthropic remote API.
         Args:
             messages: A message history. For example:
@@ -143,37 +139,31 @@ class AnthropicModel(backends.Model):
             The generated response message returned by the Anthropic remote API.
         """
         prompt, system_message = self.encode_messages(messages)
-
-        if 'thinking_mode' not in self.model_spec.model_config:
-
-            completion = self.client.messages.create(
-                messages=prompt,
-                system=system_message,
-                model=self.model_spec.model_id,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens
-            )
-
-            json_output = completion.model_dump_json()
-            response = json.loads(json_output)
-            response_text = completion.content[0].text
-
-        else:
+        gen_kwargs = dict(
+            messages=prompt,
+            system=system_message,
+            model=self.model_spec.model_id,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens
+        )
+        content_index = 0
+        if 'thinking_mode' in self.model_spec.model_config:
+            """
+            Feature compatibility:
+            - Thinking isn't compatible with temperature or top_k modifications as well as forced tool use.
+            - When thinking is enabled, you can set top_p to values between 1 and 0.95.
+            - You cannot pre-fill responses when thinking is enabled.
+            - Changes to the thinking budget invalidate cached prompt prefixes that include messages. 
+            - However, cached system prompts and tool definitions will continue to work when thinking parameters change.
+            https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+            """
             # set thinking token budget to 4K
             # max_tokens should be higher than 4K -> so we set to 4K + get_max_tokens()
-            completion = self.client.messages.create(
-                messages=prompt,
-                system=system_message,
-                model=self.model_spec.model_id,
-                max_tokens=4000 + self.max_tokens,
-                thinking={
-                    "type": "enabled",
-                    "budget_tokens": 4000
-                },
-            )
-
-            json_output = completion.model_dump_json()
-            response = json.loads(json_output)
-            response_text = completion.content[1].text
-
+            content_index = 1
+            gen_kwargs["temperature"] = 1.  # todo: we need to use self.gen_args for this (user should decide)
+            gen_kwargs["max_tokens"] = 4000 + self.max_tokens # todo: we need to use self.gen_args for this
+            gen_kwargs["thinking"] = {"type": "enabled", "budget_tokens": 4000}
+        completion = self.client.messages.create(**gen_kwargs)
+        response_text = completion.content[content_index].text
+        response = completion.model_dump(mode="json")
         return prompt, response, response_text

--- a/clemcore/backends/cohere_api.py
+++ b/clemcore/backends/cohere_api.py
@@ -59,6 +59,8 @@ class CohereModel(backends.Model):
             temperature=self.temperature,
             max_tokens=self.max_tokens
         )
+        if result.message.role != "assistant":  # safety check
+            raise AttributeError("Response message role is " + result.message.role + " but should be 'assistant'")
         response_text = result.message.content[0].text
         response = result.model_dump(mode="json")
         return messages, response, response_text

--- a/clemcore/backends/cohere_api.py
+++ b/clemcore/backends/cohere_api.py
@@ -28,7 +28,7 @@ class Cohere(backends.RemoteBackend):
 class CohereModel(backends.Model):
     """Model class accessing the Cohere remote API."""
 
-    def __init__(self, client: cohere.Client, model_spec: backends.ModelSpec):
+    def __init__(self, client: cohere.ClientV2, model_spec: backends.ModelSpec):
         """
         Args:
             client: A Cohere library Client class.
@@ -54,7 +54,7 @@ class CohereModel(backends.Model):
             The generated response message returned by the Cohere remote API.
         """
         result: cohere.V2ChatResponse = self.client.chat(
-            messages=messages,
+            messages=messages,  # type: ignore[arg-type]
             model=self.model_spec.model_id,
             temperature=self.temperature,
             max_tokens=self.max_tokens

--- a/clemcore/backends/cohere_api.py
+++ b/clemcore/backends/cohere_api.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class Cohere(backends.RemoteBackend):
     """Backend class for accessing the Cohere remote API."""
     def _make_api_client(self):
-        self.client = cohere.Client(self.key["api_key"])
+        return cohere.Client(self.key["api_key"])
 
     def get_model_for(self, model_spec: backends.ModelSpec) -> backends.Model:
         """Get a Cohere model instance based on a model specification.

--- a/clemcore/backends/cohere_api.py
+++ b/clemcore/backends/cohere_api.py
@@ -37,7 +37,7 @@ class CohereModel(backends.Model):
         super().__init__(model_spec)
         self.client = client
 
-    @retry(tries=3, delay=0, logger=logger)
+    @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
     def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:

--- a/clemcore/backends/cohere_api.py
+++ b/clemcore/backends/cohere_api.py
@@ -2,7 +2,6 @@ import logging
 from typing import List, Dict, Tuple, Any
 from retry import retry
 import cohere
-import json
 
 import clemcore.backends as backends
 from clemcore.backends.utils import ensure_messages_format, augment_response_object
@@ -12,8 +11,9 @@ logger = logging.getLogger(__name__)
 
 class Cohere(backends.RemoteBackend):
     """Backend class for accessing the Cohere remote API."""
+
     def _make_api_client(self):
-        return cohere.Client(self.key["api_key"])
+        return cohere.ClientV2(self.key["api_key"])
 
     def get_model_for(self, model_spec: backends.ModelSpec) -> backends.Model:
         """Get a Cohere model instance based on a model specification.
@@ -27,6 +27,7 @@ class Cohere(backends.RemoteBackend):
 
 class CohereModel(backends.Model):
     """Model class accessing the Cohere remote API."""
+
     def __init__(self, client: cohere.Client, model_spec: backends.ModelSpec):
         """
         Args:
@@ -39,7 +40,7 @@ class CohereModel(backends.Model):
     @retry(tries=3, delay=0, logger=logger)
     @augment_response_object
     @ensure_messages_format
-    def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:
+    def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:
         """Request a generated response from the Cohere remote API.
         Args:
             messages: A message history. For example:
@@ -52,34 +53,12 @@ class CohereModel(backends.Model):
         Returns:
             The generated response message returned by the Cohere remote API.
         """
-        chat_history = []
-
-        # all other messages except the last one. It is passed to the API with the variable message.
-        for message in messages[:-1]:
-
-            if message['role'] == 'assistant':
-                m = {"role": "CHATBOT", "message": message["content"]}
-                chat_history.append(m)
-            elif message['role'] == 'user':
-                m = {"role": "USER", "message": message["content"]}
-                chat_history.append(m)
-
-        message = messages[-1]["content"]
-
-        output = self.client.chat(
-            message=message,
+        result: cohere.V2ChatResponse = self.client.chat(
+            messages=messages,
             model=self.model_spec.model_id,
-            chat_history=chat_history,
             temperature=self.temperature,
-            max_tokens = self.max_tokens
+            max_tokens=self.max_tokens
         )
-
-        response_text = output.text
-        prompt = json.dumps({"message": message, "chat_history": chat_history})
-
-        response = output.__dict__
-        # This fix is removing the 'client' key, only when it is available.
-        response.pop('client', None)
-        response.pop('token_count', None)
-
-        return prompt, response, response_text
+        response_text = result.message.content[0].text
+        response = result.model_dump(mode="json")
+        return messages, response, response_text

--- a/clemcore/backends/google_api.py
+++ b/clemcore/backends/google_api.py
@@ -1,7 +1,8 @@
 import logging
 from typing import List, Dict, Tuple, Any, Union
 from retry import retry
-import google.generativeai as genai
+from google import genai
+from google.genai import types
 import os
 import requests
 import uuid
@@ -16,8 +17,9 @@ logger = logging.getLogger(__name__)
 
 class Google(backends.RemoteBackend):
     """Backend class for accessing the Google remote API."""
+
     def _make_api_client(self):
-        genai.configure(api_key=self.key["api_key"])
+        return genai.Client(api_key=self.key["api_key"])
 
     def get_model_for(self, model_spec: backends.ModelSpec) -> backends.Model:
         """Get a Google model instance based on a model specification.
@@ -26,21 +28,20 @@ class Google(backends.RemoteBackend):
         Returns:
             A Google model instance based on the passed model specification.
         """
-        return GoogleModel(model_spec)
+        return GoogleModel(self.client, model_spec)
 
 
 class GoogleModel(backends.Model):
     """Model class accessing the Google remote API."""
-    def __init__(self, model_spec: backends.ModelSpec):
+
+    def __init__(self, client: genai.Client, model_spec: backends.ModelSpec):
         """
         Args:
+            client: A Google genai Client class.
             model_spec: A ModelSpec instance specifying the model.
         """
         super().__init__(model_spec)
-
-        self.model = genai.GenerativeModel(
-            model_name=model_spec.model_id
-        )
+        self.client = client
 
     def download_image(self, image_url) -> Union[str, None]:
         """Download an image from a URL.
@@ -49,23 +50,15 @@ class GoogleModel(backends.Model):
         Returns:
             The file path to the downloaded image or None if the image could not be downloaded.
         """
-        # Create a temporary directory
         temp_dir = tempfile.mkdtemp()
-
         try:
-            # Send a GET request to the URL
             response = requests.get(image_url)
             response.raise_for_status()
-
-            # Generate a unique file name
             unique_name = str(uuid.uuid4()) + '.jpg'
             file_path = os.path.join(temp_dir, unique_name)
-
-            # Write the image content to a file
             with open(file_path, 'wb') as file:
                 file.write(response.content)
             return file_path
-
         except requests.RequestException as e:
             print(f"Failed to download {image_url}: {e}")
             return None
@@ -77,28 +70,25 @@ class GoogleModel(backends.Model):
             file_path: Path to the file to upload.
             mime_type: The mime type of the file to upload.
         Returns:
-            The (URL of the) uploaded file.
+            The uploaded file reference.
         """
-        file_url = genai.upload_file(file_path, mime_type=mime_type)
-        return file_url
+        file_ref = self.client.files.upload(file=file_path, config={"mime_type": mime_type})
+        return file_ref
 
     def encode_images(self, images):
         """Encode images and upload them to Gemini allow sending them to the Google remote API.
         Args:
             images: Paths to the images to be encoded.
         Returns:
-            A list of the (URLs of the) encoded and uploaded files.
+            A list of the uploaded file references.
         """
         image_parts = []
-
         for image_path in images:
             if image_path.startswith('http'):
                 image_path = self.download_image(image_path)
-
             image_type = imghdr.what(image_path)
-            # upload to Gemini server
-            file_url = self.upload_file(image_path, 'image/'+image_type)
-            image_parts.append(file_url)
+            file_ref = self.upload_file(image_path, 'image/' + image_type)
+            image_parts.append(file_ref)
         return image_parts
 
     def encode_messages(self, messages):
@@ -112,49 +102,58 @@ class GoogleModel(backends.Model):
                     {"role": "user", "content": "Where was it played?"}
                 ]
         Returns:
-            A tuple of the message history list with encoded images and the message history list for logging.
+            A list of Content objects for the Google API.
         """
         encoded_messages = []
-        encoded_messages_for_logging = []
 
         for message in messages:
+            if message['role'] == 'system':
+                # System messages are handled separately via system_instruction
+                continue
             if message['role'] == 'assistant':
-                m = {"role": "model", "parts": [message["content"]]}
-                m_for_logging = {"role": "model", "parts": [message["content"]]}
-            elif message['role'] == 'user':
-                m = {"role": "user", "parts": [message["content"]]}
-                m_for_logging = {"role": "model", "parts": [message["content"]]}
-
+                encoded_messages.append(types.Content(
+                    role="model",
+                    parts=[types.Part(text=message["content"])]
+                ))
+            if message['role'] == 'user':
+                parts = [types.Part(text=message["content"])]
                 if "image" in message.keys() and 'multimodality' not in self.model_spec.model_config:
                     logger.info(
-                        f"The backend {self.model_spec.__getattribute__('model_id')} does not support multimodal inputs!")
+                        f"The backend {self.model_spec.model_id} does not support multimodal inputs!")
                     raise Exception(
-                        f"The backend {self.model_spec.__getattribute__('model_id')} does not support multimodal inputs!")
-
+                        f"The backend {self.model_spec.model_id} does not support multimodal inputs!")
                 if 'multimodality' in self.model_spec.model_config:
                     if "image" in message.keys():
-
-                        if not self.model_spec['model_config']['multimodality']['multiple_images'] and len(message['image']) > 1:
+                        if not self.model_spec.model_config['multimodality']['multiple_images'] and len(
+                                message['image']) > 1:
                             logger.info(
-                                f"The backend {self.model_spec.__getattribute__('model_id')} does not support multiple images!")
+                                f"The backend {self.model_spec.model_id} does not support multiple images!")
                             raise Exception(
-                                f"The backend {self.model_spec.__getattribute__('model_id')} does not support multiple images!")
+                                f"The backend {self.model_spec.model_id} does not support multiple images!")
                         else:
                             image_parts = self.encode_images(message['image'])
-                            for i in image_parts:
-                                m["parts"].append(i)
+                            for img in image_parts:
+                                parts.append(types.Part(file_data=img))
+                encoded_messages.append(types.Content(role="user", parts=parts))
 
-                            # for logging purposes
-                            m_for_logging["parts"].append(message["image"])
+        return encoded_messages
 
-            encoded_messages.append(m)
-            encoded_messages_for_logging.append(m_for_logging)
-        return encoded_messages, encoded_messages_for_logging
+    def extract_system_instruction(self, messages):
+        """Extract system instruction from messages.
+        Args:
+            messages: A message history.
+        Returns:
+            The system instruction string or None.
+        """
+        for message in messages:
+            if message['role'] == 'system':
+                return message['content']
+        return None
 
-    @retry(tries=10, delay=120, logger=logger)
+    @retry(tries=3, delay=90, logger=logger)
     @augment_response_object
     @ensure_messages_format
-    def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:
+    def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:
         """Request a generated response from the Google remote API.
         Args:
             messages: A message history. For example:
@@ -167,50 +166,55 @@ class GoogleModel(backends.Model):
         Returns:
             The generated response message returned by the Google remote API.
         """
+        encoded_messages = self.encode_messages(messages)
+        system_instruction = self.extract_system_instruction(messages)
 
-        generation_config = {
-            "temperature": self.temperature,
-            "max_output_tokens": self.max_tokens,
-            "response_mime_type": "text/plain",
-        }
+        config = types.GenerateContentConfig(
+            temperature=self.temperature,
+            max_output_tokens=self.max_tokens,
+            safety_settings=[
+                types.SafetySetting(
+                    category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+                    threshold=types.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
+                ),
+                types.SafetySetting(
+                    category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+                    threshold=types.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
+                ),
+                types.SafetySetting(
+                    category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+                    threshold=types.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
+                ),
+                types.SafetySetting(
+                    category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+                    threshold=types.HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
+                ),
+            ],
+        )
 
-        safety_settings = [
-            {
-                "category": "HARM_CATEGORY_HARASSMENT",
-                "threshold": "BLOCK_MEDIUM_AND_ABOVE",
-            },
-            {
-                "category": "HARM_CATEGORY_HATE_SPEECH",
-                "threshold": "BLOCK_MEDIUM_AND_ABOVE",
-            },
-            {
-                "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-                "threshold": "BLOCK_MEDIUM_AND_ABOVE",
-            },
-            {
-                "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
-                "threshold": "BLOCK_MEDIUM_AND_ABOVE",
-            },
-        ]
+        if system_instruction:
+            config.system_instruction = system_instruction
 
-        encoded_messages, encoded_messages_for_logging = self.encode_messages(messages)
+        if 'thinking_mode' in self.model_spec.model_config:
+            """
+            Thinking mode for Gemini 2.5 models uses thinking_budget parameter.
+            https://ai.google.dev/gemini-api/docs/thinking
+            Note: Gemini-3 models are not yet supported out of the box here
+            """
+            # Increase max_output_tokens to account for thinking budget (similar to Anthropic)
+            config.max_output_tokens = 4096 + self.max_tokens
+            config.thinking_config = types.ThinkingConfig(thinking_budget=4096)
 
-        response = self.model.generate_content(
+        result: types.GenerateContentResponse = self.client.models.generate_content(
+            model=self.model_spec.model_id,
             contents=encoded_messages,
-            safety_settings=safety_settings,
-            generation_config=generation_config)
+            config=config
+        )
 
-        # print('Putting to sleep for 60 sec')
-        # time.sleep(120)
+        response_text = (result.text or "").strip()
 
-        response_text = ''
-        response_json = {}
-        if response.parts:
-            response_text = response.text.strip()
-            response_json = {"text": response_text}
+        if not response_text:
+            logger.warning("Google API response message content is None or empty, returning empty string.")
 
-        if response_text == '':
-            logger.error(
-                f"The backend {self.model_spec.__getattribute__('model_id')} returned empty string!")
-
-        return encoded_messages_for_logging, response_json, response_text
+        response = result.model_dump(mode="json")
+        return encoded_messages, response, response_text

--- a/clemcore/backends/google_api.py
+++ b/clemcore/backends/google_api.py
@@ -150,7 +150,7 @@ class GoogleModel(backends.Model):
                 return message['content']
         return None
 
-    @retry(tries=3, delay=90, logger=logger)
+    @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
     def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:

--- a/clemcore/backends/google_api.py
+++ b/clemcore/backends/google_api.py
@@ -210,6 +210,9 @@ class GoogleModel(backends.Model):
             contents=encoded_messages,
             config=config
         )
+        response_role = result.candidates[0].content.role
+        if response_role != "model":  # safety check (Google uses "model" instead of "assistant")
+            raise AttributeError("Response message role is " + response_role + " but should be 'model'")
 
         response_text = (result.text or "").strip()
 

--- a/clemcore/backends/google_api.py
+++ b/clemcore/backends/google_api.py
@@ -110,11 +110,8 @@ class GoogleModel(backends.Model):
             if message['role'] == 'system':
                 # System messages are handled separately via system_instruction
                 continue
-            if message['role'] == 'assistant':
-                encoded_messages.append(types.Content(
-                    role="model",
-                    parts=[types.Part(text=message["content"])]
-                ))
+            if message['role'] in ('assistant', 'model'):
+                encoded_messages.append(types.Content(role="model", parts=[types.Part(text=message["content"])]))
             if message['role'] == 'user':
                 parts = [types.Part(text=message["content"])]
                 if "image" in message.keys() and 'multimodality' not in self.model_spec.model_config:
@@ -211,7 +208,9 @@ class GoogleModel(backends.Model):
             config=config
         )
         response_role = result.candidates[0].content.role
-        if response_role != "model":  # safety check (Google uses "model" instead of "assistant")
+        if response_role != "model":  # safety check
+            # Note: Google uses 'model' instead of 'assistant' in the response, but this is fine,
+            # because the user will form a message with role=assistant from the returned response_text
             raise AttributeError("Response message role is " + response_role + " but should be 'model'")
 
         response_text = (result.text or "").strip()

--- a/clemcore/backends/mistral_api.py
+++ b/clemcore/backends/mistral_api.py
@@ -45,7 +45,7 @@ class MistralModel(backends.Model):
         super().__init__(model_spec)
         self.client = client
 
-    @retry(tries=3, delay=0, logger=logger)
+    @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
     def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:

--- a/clemcore/backends/mistral_api.py
+++ b/clemcore/backends/mistral_api.py
@@ -1,8 +1,7 @@
 import logging
-from mistralai import Mistral as MistralClient
+import mistralai
 from typing import List, Dict, Tuple, Any
 from retry import retry
-import json
 import clemcore.backends as backends
 from clemcore.backends.utils import ensure_messages_format, augment_response_object
 
@@ -11,8 +10,9 @@ logger = logging.getLogger(__name__)
 
 class Mistral(backends.RemoteBackend):
     """Backend class for accessing the Mistral remote API."""
+
     def _make_api_client(self):
-        return MistralClient(api_key=self.key["api_key"])
+        return mistralai.Mistral(api_key=self.key["api_key"])
 
     def list_models(self) -> list:
         """List models available on the Mistral remote API.
@@ -36,7 +36,8 @@ class Mistral(backends.RemoteBackend):
 
 class MistralModel(backends.Model):
     """Model class accessing the Mistral remote API."""
-    def __init__(self, client: MistralClient, model_spec: backends.ModelSpec):
+
+    def __init__(self, client: mistralai.Mistral, model_spec: backends.ModelSpec):
         """
         Args:
             client: An Mistral library MistralClient class.
@@ -48,7 +49,7 @@ class MistralModel(backends.Model):
     @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
-    def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:
+    def generate_response(self, messages: List[Dict]) -> Tuple[Any, Any, str]:
         """Request a generated response from the Mistral remote API.
         Args:
             messages: A message history. For example:
@@ -61,14 +62,15 @@ class MistralModel(backends.Model):
         Returns:
             The generated response message returned by the Mistral remote API.
         """
-        api_response = self.client.chat.complete(model=self.model_spec.model_id,
-                                                 messages=messages,
-                                                 temperature=self.temperature,
-                                                 max_tokens=self.max_tokens)
+        api_response: mistralai.ChatCompletionResponse = self.client.chat.complete(
+            model=self.model_spec.model_id,
+            messages=messages,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens
+        )
         message = api_response.choices[0].message
         if message.role != "assistant":  # safety check
-            raise AttributeError("Response message role is " + message.role + " but should be 'assistant'")
-        response_text = message.content.strip()
-        response = json.loads(api_response.model_dump_json())
-
+            raise AttributeError(f"Response message role '{message.role}' but should be 'assistant'")
+        response_text = (message.content or "").strip()
+        response = api_response.model_dump(mode="json")
         return messages, response, response_text

--- a/clemcore/backends/mistral_api.py
+++ b/clemcore/backends/mistral_api.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class Mistral(backends.RemoteBackend):
     """Backend class for accessing the Mistral remote API."""
     def _make_api_client(self):
-        self.client = MistralClient(api_key=self.key["api_key"])
+        return MistralClient(api_key=self.key["api_key"])
 
     def list_models(self) -> list:
         """List models available on the Mistral remote API.

--- a/clemcore/backends/openai_api.py
+++ b/clemcore/backends/openai_api.py
@@ -121,7 +121,7 @@ class OpenAIModel(backends.Model):
                 encoded_messages.append(this)
         return encoded_messages
 
-    @retry(tries=3, delay=90, logger=logger)
+    @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
     def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:

--- a/clemcore/backends/openai_api.py
+++ b/clemcore/backends/openai_api.py
@@ -152,9 +152,11 @@ class OpenAIModel(backends.Model):
             logger.info("Ignoring max_tokens for reasoning models, because the argument is not supported")
             del gen_kwargs["max_tokens"]
 
-        logger.debug(f"Calling OpenAI API with parameters: {json.dumps(gen_kwargs, indent=2)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Calling OpenAI API with parameters: {json.dumps(gen_kwargs, indent=2)}")
         api_response = self.client.chat.completions.create(**gen_kwargs)
-        logger.debug(f"OpenAI API response: {api_response.model_dump_json(indent=2)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"OpenAI API response: {api_response.model_dump_json(indent=2)}")
 
         message = api_response.choices[0].message
         if message.role != "assistant":  # safety check

--- a/clemcore/backends/openrouter_api.py
+++ b/clemcore/backends/openrouter_api.py
@@ -54,7 +54,7 @@ class OpenRouterModel(openai_api.OpenAIModel):
         super().__init__(client, model_spec)
         self.client = client
 
-    @retry(tries=3, delay=90, logger=logger)
+    @retry(tries=3, delay=10, logger=logger)
     @augment_response_object
     @ensure_messages_format
     def generate_response(self, messages: List[Dict]) -> Tuple[str, Any, str]:

--- a/key.json.template
+++ b/key.json.template
@@ -6,10 +6,13 @@
   "anthropic": {
     "api_key": ""
   },
-  "huggingface": {
+  "mistral": {
     "api_key": ""
   },
   "cohere": {
+    "api_key": ""
+  },
+  "huggingface": {
     "api_key": ""
   },
   "slurk": {

--- a/key.json.template
+++ b/key.json.template
@@ -12,6 +12,9 @@
   "cohere": {
     "api_key": ""
   },
+  "google": {
+    "api_key": ""
+  },
   "huggingface": {
     "api_key": ""
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,18 @@ dependencies = [
     "retry>=0.9.2",
     "tqdm>=4.65.0",
     "nltk==3.8.1", # pin due to transformers==4.51.1 requires nltk<=3.8.1
-    "openai==1.99.9",
-    "anthropic==0.64.0",
-    "cohere==5.17",
-    "google-generativeai==0.8.5",
-    "mistralai==1.9.6",
+    "openai>=2.15.0,<3.0.0",
+    "anthropic>=0.75.0,<1.0.0",
+    "cohere>=5.17.0,<6.0.0",
+    "google-genai>=1.57.0,<2.0.0",
+    "mistralai~=1.10.0",
     "matplotlib==3.7.1",
     "pandas==2.0.1",
     "seaborn==0.12.2",
     "sparklines~=0.7.0",
     "pylatex~=1.4.2", # transcripts
     "ordered-set~=4.1.0", # transcripts
-    "markdown~=3.8.2",       # transcripts
+    "markdown~=3.8.2", # transcripts
     "pettingzoo~=1.25.0", # to wrap games as pettingzoo or gymnasium environments
     "openenv-core~=0.1.1", # to serve games as openenv server
     "datasets~=4.4.1" # to load playpen-data for openenv server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "nltk==3.8.1", # pin due to transformers==4.51.1 requires nltk<=3.8.1
     "openai>=2.15.0,<3.0.0",
     "anthropic>=0.75.0,<1.0.0",
-    "cohere>=5.17.0,<6.0.0",
+    "cohere>=5.20.1,<6.0.0",
     "google-genai>=1.57.0,<2.0.0",
     "mistralai~=1.10.0",
     "matplotlib==3.7.1",

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -3,18 +3,20 @@ import unittest
 from clemcore.backends import ModelRegistry, ModelSpec
 from clemcore.backends.anthropic_api import Anthropic
 from clemcore.backends.cohere_api import Cohere
+from clemcore.backends.google_api import Google
 from clemcore.backends.mistral_api import Mistral
 from clemcore.backends.openai_api import OpenAI
 from clemcore.backends.utils import ensure_alternating_roles
 
 
-class GenerateTestCase(unittest.TestCase):
+class BackendTestCase(unittest.TestCase):
 
-    def _generate_response_test(self, backend, model_name, messages):
-        model_spec = ModelSpec.from_dict(dict(model_name=model_name, model_id=model_name, model_config={}))
+    def generate_response_test(self, backend, model_name, messages, *, model_config=None):
+        model_config = model_config or {}
+        model_spec = ModelSpec.from_dict(dict(model_name=model_name, model_id=model_name, model_config=model_config))
         model = backend.get_model_for(model_spec)
         model.set_gen_arg("temperature", 0)
-        model.set_gen_arg("max_tokens", 100)
+        model.set_gen_arg("max_tokens", 100)  # will be overwritten in backends when thinking_mode=True
         prompt, response, response_text = model.generate_response(messages)
         assert prompt is not None
         print(prompt)
@@ -22,29 +24,67 @@ class GenerateTestCase(unittest.TestCase):
         assert response_text is not None
         print(response_text)
 
-    def test_generate_response_with_openai(self):
-        self._generate_response_test(
+
+class OpenAIBackendTestCase(BackendTestCase):
+
+    def test_generate_response(self):
+        self.generate_response_test(
             OpenAI(),
             "gpt-4o-mini-2024-07-18",
             [{"role": "user", "content": "How are you?"}]
         )
 
-    def test_generate_response_with_anthropic(self):
-        self._generate_response_test(
+
+class GoogleBackendTestCase(BackendTestCase):
+
+    def test_generate_response(self):
+        self.generate_response_test(
+            Google(),
+            "gemini-2.5-flash",
+            [{"role": "user", "content": "How are you?"}]
+        )
+
+    def test_generate_response_thinking(self):
+        self.generate_response_test(
+            Google(),
+            "gemini-2.5-flash",
+            [{"role": "user", "content": "How are you?"}],
+            model_config={"thinking_mode": True}
+        )
+
+
+class AnthropicBackendTestCase(BackendTestCase):
+
+    def test_generate_response(self):
+        self.generate_response_test(
             Anthropic(),
-            "claude-3-haiku-20240307",
+            "claude-haiku-4-5",
             [{"role": "user", "content": "How are you?"}]
         )
 
-    def test_generate_response_with_cohere(self):
-        self._generate_response_test(
+    def test_generate_response_thinking(self):
+        self.generate_response_test(
+            Anthropic(),
+            "claude-haiku-4-5",
+            [{"role": "user", "content": "How are you?"}],
+            model_config={"thinking_mode": True}
+        )
+
+
+class CohereBackendTestCase(BackendTestCase):
+
+    def test_generate_response(self):
+        self.generate_response_test(
             Cohere(),
-            "command-r",
+            "command-a-03-2025",
             [{"role": "user", "content": "How are you?"}]
         )
 
-    def test_generate_response_with_mistral(self):
-        self._generate_response_test(
+
+class MistralBackendTestCase(BackendTestCase):
+
+    def test_generate_response(self):
+        self.generate_response_test(
             Mistral(),
             "mistral-small-latest",
             [{"role": "user", "content": "How are you?"}]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,7 +1,9 @@
 import unittest
 
-from clemcore.backends import ModelRegistry, BackendRegistry, ModelSpec
+from clemcore.backends import ModelRegistry, ModelSpec
 from clemcore.backends.anthropic_api import Anthropic
+from clemcore.backends.cohere_api import Cohere
+from clemcore.backends.mistral_api import Mistral
 from clemcore.backends.openai_api import OpenAI
 from clemcore.backends.utils import ensure_alternating_roles
 
@@ -31,6 +33,20 @@ class GenerateTestCase(unittest.TestCase):
         self._generate_response_test(
             Anthropic(),
             "claude-3-haiku-20240307",
+            [{"role": "user", "content": "How are you?"}]
+        )
+
+    def test_generate_response_with_cohere(self):
+        self._generate_response_test(
+            Cohere(),
+            "command-r",
+            [{"role": "user", "content": "How are you?"}]
+        )
+
+    def test_generate_response_with_mistral(self):
+        self._generate_response_test(
+            Mistral(),
+            "mistral-small-latest",
             [{"role": "user", "content": "How are you?"}]
         )
 


### PR DESCRIPTION
## Summary

- **Bump and Relax API client versions** in pyproject.toml:
  - `openai>=2.15.0,<3.0.0`
  - `anthropic>=0.75.0,<1.0.0`
  - `cohere>=5.17.0,<6.0.0`
  - `google-genai>=1.57.0,<2.0.0` (migrated from legacy `google-generativeai`)
  - `mistralai~=1.10.0`

- **Google API refactor** (`google_api.py`):
  - Migrated from legacy `google-generativeai` to new `google-genai` SDK
  - Use `genai.Client()` and `client.models.generate_content()`
  - Use proper `types.Content` and `types.Part` objects (SDK validates input)
  - Added thinking mode support via `types.ThinkingConfig(thinking_budget=4096)`
  - Handle both 'assistant' and 'model' roles in input messages

- **Cohere API refactor** (`cohere_api.py`):
  - Migrated from v4 to v5 API using `cohere.ClientV2`
  - Use new unified `messages` parameter instead of `message` + `chat_history`

- **Anthropic API** (`anthropic_api.py`):
  - Fixed type hint to `anthropic.Anthropic`
  - Refactored `generate_response` to use `gen_kwargs` dict pattern

- **Added response role safety checks** to all backends:
  - OpenAI, Mistral: check for `"assistant"`
  - Anthropic, Cohere: check for `"assistant"`
  - Google: check for `"model"` (Google's equivalent)

- **For all RemoteBackend**:
  - Reduced retry delay to 10 seconds
  - Fixed _make_client method now returning the client

- **Test improvements** (`tests/test_backend.py`):
  - Added thinking mode tests for Anthropic and Google
  - Updated model names

## Test plan
- [x] Run `python -m pytest tests/test_backend.py` for each backend
- [x] Verify thinking mode works for Anthropic (`claude-haiku-4-5`)
- [x] Verify thinking mode works for Google (`gemini-2.5-flash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)