### PR TITLE
Improve error logging and defensive timeout handling in slurk backend

### DIFF
--- a/clemcore/backends/slurk_api.py
+++ b/clemcore/backends/slurk_api.py
@@ -4,7 +4,6 @@ from typing import List, Dict, Tuple, Any
 
 import requests
 import socketio
-from retry import retry
 
 from clemcore import backends
 from clemcore.backends import ModelSpec, Model
@@ -125,6 +124,14 @@ class SlurkModel(backends.Model):  # todo: make this HumanModel when HumanModel 
 
     def __init__(self, user_id: int, user_token: str, room_id: int, model_spec: ModelSpec):
         super().__init__(model_spec)
+        self.join_timeout = self.model_spec.get("join_timeout")
+        if self.join_timeout is None:
+            self.join_timeout = 300
+            stdout_logger.warning(f"Missing join_timeout in ModelSpec. Using default value of {self.join_timeout}.")
+        self.response_timeout = self.model_spec.get("response_timeout")
+        if self.response_timeout is None:
+            self.response_timeout = 300
+            stdout_logger.warning(f"Missing response_timeout in ModelSpec. Using default value of {self.response_timeout}.")
         self.user_id = user_id
         self.user_token = user_token
         self.sio = socketio.Client(logger=logger)
@@ -158,7 +165,7 @@ class SlurkModel(backends.Model):  # todo: make this HumanModel when HumanModel 
         if messages:
             latest_response = messages[-1]["content"]
         self.sio.emit("text", {"message": latest_response, "room": self.room_id})
-        if not self.sync_event.wait(timeout=self.model_spec.response_timeout):
+        if not self.sync_event.wait(timeout=self.response_timeout):
             pass  # no user response
         self.sync_event.clear()
         user_response = self.user_messages[0]
@@ -167,7 +174,7 @@ class SlurkModel(backends.Model):  # todo: make this HumanModel when HumanModel 
 
     def wait_for_participant(self):
         # this works because: self.sio.on("status", check_and_unblock)
-        if not self.sync_event.wait(timeout=self.model_spec.join_timeout):
+        if not self.sync_event.wait(timeout=self.join_timeout):
             raise RuntimeError("no user joined the slurk room")
         self.sync_event.clear()
 

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -503,7 +503,11 @@ Update Behavior:
                               help="Identifier for this run, used as subdirectory name in results-dir. "
                                    "If not provided, derived from env-agent model names (e.g., 'gpt-4o-llama3'), "
                                    "otherwise defaults to 'run'.")
-    cli(parser.parse_args())
+    try:  # catch all unexpected exceptions to ensure proper logging
+        cli(parser.parse_args())
+    except Exception as e:
+        logger.exception(e)
+        raise
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+
+from clemcore.cli import main
+
+
+class CLIExceptionLoggingTestCase(unittest.TestCase):
+    """Test that exceptions during CLI commands are properly logged."""
+
+    def test_run_exception_is_logged(self):
+        """Verify that exceptions during 'clem run' are logged before re-raising."""
+        # Use a non-existent model to trigger an error during load_models
+        test_args = ["clem", "run", "-g", "nonexistent_game", "-m", "nonexistent_model"]
+
+        with patch("sys.argv", test_args):
+            with patch("clemcore.cli.logger") as mock_logger:
+                with self.assertRaises(Exception):
+                    main()
+
+                # Verify logger.exception was called with the exception
+                mock_logger.exception.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add try/except in `cli.main()` to ensure all unexpected exceptions are logged via `logger.exception()` before re-raising - fixes issue where errors during model loading (e.g., in slurk_api.py) weren't being written to clembench.log
- Handle missing `join_timeout`/`response_timeout` in `SlurkModel` defensively with sensible defaults (300s) and warning logs
- Add test to verify CLI exception logging behavior

## Test plan
- [x] Run `python -m pytest tests/test_cli.py` - passes
- [ ] Verify errors during `clem run` now appear in clembench.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)