### PR TITLE
Refactor request logging to per-player files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ours
 key*.json
+model_registry*.json
 *results*
 openenv-records*/
 /venv

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -97,6 +97,14 @@ class GameMaster(EnvLike, GameEventSource):
     def has_started(self) -> bool:
         pass
 
+    @abc.abstractmethod
+    def get_players(self) -> list[Player]:
+        """Get a list of the players.
+        Returns:
+            List of Player instances in the order they are added.
+        """
+        pass
+
 
 class DialogueGameMaster(GameMaster):
     """Extended GameMaster, implementing turns as described in the clembench paper.

--- a/clemcore/clemgame/recorder.py
+++ b/clemcore/clemgame/recorder.py
@@ -24,7 +24,9 @@ class GameInteractionsRecorder(GameEventLogger):
                          experiment_name=experiment_name,
                          game_id=game_id,
                          results_folder=results_folder,
-                         clem_version=get_version()),
+                         clem_version=get_version(),
+                         round_count=None,
+                         completed=None),
             "player_models": player_model_infos,
             # already add Game Master
             "players": collections.OrderedDict(GM=dict(game_role="Game Master", model_name="programmatic")),
@@ -39,6 +41,7 @@ class GameInteractionsRecorder(GameEventLogger):
     def log_next_round(self):
         """Call this method to group interactions per turn."""
         self._current_round += 1
+        self.interactions["meta"]["round_count"] = self._current_round + 1
         self.interactions["turns"].append([])
         self.requests_counts.append(0)
         self.violated_requests_counts.append(0)
@@ -107,6 +110,10 @@ class GameInteractionsRecorder(GameEventLogger):
                 module_logger.warning(f"Invalid player identifiers, html builder won't work.")
         if not self.interactions["turns"]:
             module_logger.warning(f"Interaction logs are missing!")
+
+        # games ending in round 0 never call log_next_round, so set round_count here
+        self.interactions["meta"]["round_count"] = self._current_round + 1
+        self.interactions["meta"]["completed"] = True
 
         # add default framework metrics
         if auto_count_logging:

--- a/clemcore/clemgame/recorder.py
+++ b/clemcore/clemgame/recorder.py
@@ -31,8 +31,6 @@ class GameInteractionsRecorder(GameEventLogger):
             # already prepare to log the first round of turns
             "turns": [[]]
         }
-        """ Stores calls to the API """
-        self.requests = []
         """ Keep track of player response metrics"""
         self.requests_counts = [0]  # count per round (initially zero)
         self.violated_requests_counts = [0]  # count per round (initially zero)
@@ -97,30 +95,8 @@ class GameInteractionsRecorder(GameEventLogger):
             "action": action
         }
         self.interactions["turns"][self._current_round].append(copy.deepcopy(action_obj))
-        module_logger.info(
+        module_logger.debug(
             f"{self._game_name}: Logged {action['type']} action ({from_}->{to}).")
-        if call:
-            call_obj = {
-                "timestamp": timestamp,
-                "manipulated_prompt_obj": self._needs_copy(call[0]),
-                "raw_response_obj": self._needs_copy(call[1])
-            }
-            self.requests.append(call_obj)
-            module_logger.info(f"{self._game_name}: Logged a call with timestamp {timestamp}")
-
-    @staticmethod
-    def _needs_copy(call_obj):
-        """Deepcopy objects that may otherwise lead to reference issues.
-        Args:
-            call_obj: The object to be deep-copied for safety.
-        Returns:
-            The deep-copy of the passed object, or the original object if it is safe to use.
-        """
-        if isinstance(call_obj, Dict) or isinstance(call_obj, List):
-            return copy.deepcopy(call_obj)
-        elif isinstance(call_obj, str):
-            return call_obj[:]
-        return call_obj
 
     def log_game_end(self, auto_count_logging: bool = True):
         for name in self.interactions["players"]:
@@ -131,11 +107,83 @@ class GameInteractionsRecorder(GameEventLogger):
                 module_logger.warning(f"Invalid player identifiers, html builder won't work.")
         if not self.interactions["turns"]:
             module_logger.warning(f"Interaction logs are missing!")
-        if not self.requests:
-            module_logger.warning(f"No calls logged!")
 
         # add default framework metrics
         if auto_count_logging:
             self.log_key(METRIC_REQUEST_COUNT, self.requests_counts)
             self.log_key(METRIC_REQUEST_COUNT_VIOLATED, self.violated_requests_counts)
             self.log_key(METRIC_REQUEST_COUNT_PARSED, self.successful_requests_counts)
+
+
+class EventCallRecorder(GameEventLogger):
+    """ This recorder listens to events and records their call objects, if given."""
+
+    def __init__(
+            self,
+            game_name: str,
+            *,
+            experiment_name: str,
+            game_id: int,
+            player_name: str,
+            game_role: str,
+            model_name: str
+    ):
+        self.game_name = game_name
+        self.experiment_name = experiment_name
+        self.game_id = game_id
+        self.player_name = player_name
+        self.game_role = game_role
+        self.model_name = model_name
+        self.requests: dict = {
+            "meta": {
+                "game_name": game_name,
+                "experiment_name": experiment_name,
+                "game_id": game_id,
+                "player_name": player_name,
+                "game_role": game_role,
+                "model_name": model_name,
+                "round_count": None,
+                "completed": None
+            },
+            "calls": []
+        }
+        self.round = 0
+
+    def __len__(self) -> int:
+        return len(self.requests["calls"])
+
+    def log_event(self, from_: str, to: str, action: Dict, call: Tuple[Any, Any] = None):
+        if from_ != self.player_name:  # only record events from this player
+            return
+        timestamp = datetime.now().isoformat()
+        if isinstance(call, tuple):
+            call_obj = {
+                "timestamp": timestamp,
+                "manipulated_prompt_obj": copy.deepcopy(call[0]),
+                "raw_response_obj": copy.deepcopy(call[1])
+            }
+            self.requests["calls"].append(dict(round=self.round, call=call_obj))
+            module_logger.debug(f"{self.game_name}: Logged a call with timestamp {timestamp}")
+
+    def log_next_round(self):
+        # keep track of round count during gameplay, because log_game_end might not be called when errors occur
+        self.round += 1
+        self.requests["meta"]["round_count"] = self.round + 1
+
+    def log_game_end(self, auto_count_logging: bool = True):
+        # games ending in round 0 never call log_next_round, so in this case we have to set it here
+        self.requests["meta"]["round_count"] = self.round + 1
+        # the game was ended properly by the game master
+        self.requests["meta"]["completed"] = True
+
+    def count_request(self):
+        pass
+
+    def count_request_violation(self):
+        pass
+
+    def log_key(self, key: str, value: Any):
+        pass
+
+    def log_player(self, player_name: str, game_role: str, model_name: str):
+        pass

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -14,6 +14,7 @@ from clemcore.clemgame import GameRegistry, GameSpec, InstanceFileSaver, Experim
     InteractionsFileSaver, GameBenchmarkCallbackList, RunFileSaver, GameInstanceIterator, ResultsFolder, \
     GameBenchmark
 from clemcore import clemeval, get_version
+from clemcore.clemgame.callbacks.files import PlayerFileSaver
 from clemcore.clemgame.runners import dispatch
 from clemcore.clemgame.transcripts.builder import build_transcripts
 from clemcore.utils.string_utils import read_query_string
@@ -178,7 +179,8 @@ def run(game_selector: Union[str, Dict, GameSpec],
         InstanceFileSaver(results_folder),
         ExperimentFileSaver(results_folder, player_model_infos=model_infos),
         InteractionsFileSaver(results_folder, player_model_infos=model_infos),
-        RunFileSaver(results_folder, player_model_infos=model_infos)
+        RunFileSaver(results_folder, player_model_infos=model_infos),
+        PlayerFileSaver(results_folder)
     ])
 
     all_start = datetime.now()

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,191 @@
+import unittest
+
+from clemcore.clemgame.recorder import GameInteractionsRecorder, EventCallRecorder
+
+
+class TestGameInteractionsRecorder(unittest.TestCase):
+
+    def setUp(self):
+        self.recorder = GameInteractionsRecorder(
+            game_name="test_game",
+            experiment_name="test_experiment",
+            game_id=1,
+            results_folder="/tmp/results",
+            player_model_infos={"Player 1": {"model": "test-model"}}
+        )
+
+    def test_initial_meta_fields(self):
+        """round_count and completed should be None initially."""
+        meta = self.recorder.interactions["meta"]
+        self.assertIsNone(meta["round_count"])
+        self.assertIsNone(meta["completed"])
+
+    def test_log_next_round_updates_round_count(self):
+        """log_next_round should update round_count in meta."""
+        self.recorder.log_next_round()
+        self.assertEqual(self.recorder.interactions["meta"]["round_count"], 2)
+        self.recorder.log_next_round()
+        self.assertEqual(self.recorder.interactions["meta"]["round_count"], 3)
+
+    def test_log_game_end_sets_completed(self):
+        """log_game_end should set completed=True and round_count."""
+        self.recorder.log_game_end()
+        meta = self.recorder.interactions["meta"]
+        self.assertTrue(meta["completed"])
+        self.assertEqual(meta["round_count"], 1)
+
+    def test_log_game_end_after_rounds(self):
+        """log_game_end should reflect correct round_count after multiple rounds."""
+        self.recorder.log_next_round()
+        self.recorder.log_next_round()
+        self.recorder.log_game_end()
+        meta = self.recorder.interactions["meta"]
+        self.assertTrue(meta["completed"])
+        self.assertEqual(meta["round_count"], 3)
+
+
+class TestEventCallRecorder(unittest.TestCase):
+
+    def setUp(self):
+        self.recorder = EventCallRecorder(
+            game_name="test_game",
+            experiment_name="test_experiment",
+            game_id=1,
+            player_name="Player 1",
+            game_role="Guesser",
+            model_name="test-model"
+        )
+
+    def test_initial_state(self):
+        """Recorder should initialize with correct metadata and empty calls."""
+        meta = self.recorder.requests["meta"]
+        self.assertEqual(meta["game_name"], "test_game")
+        self.assertEqual(meta["experiment_name"], "test_experiment")
+        self.assertEqual(meta["game_id"], 1)
+        self.assertEqual(meta["player_name"], "Player 1")
+        self.assertEqual(meta["game_role"], "Guesser")
+        self.assertEqual(meta["model_name"], "test-model")
+        self.assertIsNone(meta["round_count"])
+        self.assertIsNone(meta["completed"])
+        self.assertEqual(self.recorder.requests["calls"], [])
+        self.assertEqual(len(self.recorder), 0)
+
+    def test_log_event_filters_by_player_name(self):
+        """log_event should ignore events not from the recorder's player."""
+        # Event from different player - should be ignored
+        self.recorder.log_event(
+            from_="Player 2",
+            to="GM",
+            action={"type": "get message", "content": "hello"},
+            call=({"prompt": "test"}, {"response": "test"})
+        )
+        self.assertEqual(len(self.recorder), 0)
+
+        # Event from GM - should be ignored
+        self.recorder.log_event(
+            from_="GM",
+            to="Player 1",
+            action={"type": "send message", "content": "hello"},
+            call=({"prompt": "test"}, {"response": "test"})
+        )
+        self.assertEqual(len(self.recorder), 0)
+
+    def test_log_event_records_matching_player(self):
+        """log_event should record events from the recorder's player."""
+        self.recorder.log_event(
+            from_="Player 1",
+            to="GM",
+            action={"type": "get message", "content": "hello"},
+            call=({"prompt": "test"}, {"response": "test"})
+        )
+        self.assertEqual(len(self.recorder), 1)
+        call_entry = self.recorder.requests["calls"][0]
+        self.assertEqual(call_entry["round"], 0)
+        self.assertIn("timestamp", call_entry["call"])
+        self.assertEqual(call_entry["call"]["manipulated_prompt_obj"], {"prompt": "test"})
+        self.assertEqual(call_entry["call"]["raw_response_obj"], {"response": "test"})
+
+    def test_log_event_ignores_none_call(self):
+        """log_event should not record when call is None."""
+        self.recorder.log_event(
+            from_="Player 1",
+            to="GM",
+            action={"type": "get message", "content": "hello"},
+            call=None
+        )
+        self.assertEqual(len(self.recorder), 0)
+
+    def test_log_event_ignores_non_tuple_call(self):
+        """log_event should only record when call is a tuple."""
+        self.recorder.log_event(
+            from_="Player 1",
+            to="GM",
+            action={"type": "get message", "content": "hello"},
+            call="not a tuple"
+        )
+        self.assertEqual(len(self.recorder), 0)
+
+    def test_log_next_round_updates_round(self):
+        """log_next_round should increment round and update round_count."""
+        self.assertEqual(self.recorder.round, 0)
+        self.recorder.log_next_round()
+        self.assertEqual(self.recorder.round, 1)
+        self.assertEqual(self.recorder.requests["meta"]["round_count"], 2)
+        self.recorder.log_next_round()
+        self.assertEqual(self.recorder.round, 2)
+        self.assertEqual(self.recorder.requests["meta"]["round_count"], 3)
+
+    def test_log_event_uses_current_round(self):
+        """log_event should tag calls with the current round number."""
+        self.recorder.log_event(
+            from_="Player 1", to="GM",
+            action={"type": "get message", "content": "r0"},
+            call=({"p": 1}, {"r": 1})
+        )
+        self.recorder.log_next_round()
+        self.recorder.log_event(
+            from_="Player 1", to="GM",
+            action={"type": "get message", "content": "r1"},
+            call=({"p": 2}, {"r": 2})
+        )
+        self.assertEqual(self.recorder.requests["calls"][0]["round"], 0)
+        self.assertEqual(self.recorder.requests["calls"][1]["round"], 1)
+
+    def test_log_game_end_sets_completed(self):
+        """log_game_end should set completed=True."""
+        self.assertIsNone(self.recorder.requests["meta"]["completed"])
+        self.recorder.log_game_end()
+        self.assertTrue(self.recorder.requests["meta"]["completed"])
+
+    def test_log_game_end_sets_round_count(self):
+        """log_game_end should set round_count even if log_next_round was never called."""
+        self.recorder.log_game_end()
+        self.assertEqual(self.recorder.requests["meta"]["round_count"], 1)
+
+    def test_log_game_end_after_rounds(self):
+        """log_game_end should reflect correct round_count after multiple rounds."""
+        self.recorder.log_next_round()
+        self.recorder.log_next_round()
+        self.recorder.log_game_end()
+        self.assertEqual(self.recorder.requests["meta"]["round_count"], 3)
+
+    def test_deepcopy_in_log_event(self):
+        """log_event should deepcopy call objects to prevent mutation issues."""
+        prompt = {"messages": [{"role": "user", "content": "hello"}]}
+        response = {"choices": [{"text": "hi"}]}
+        self.recorder.log_event(
+            from_="Player 1", to="GM",
+            action={"type": "get message", "content": "test"},
+            call=(prompt, response)
+        )
+        # Mutate original objects
+        prompt["messages"].append({"role": "assistant", "content": "mutated"})
+        response["choices"].append({"text": "mutated"})
+        # Recorded call should be unchanged
+        recorded = self.recorder.requests["calls"][0]["call"]
+        self.assertEqual(len(recorded["manipulated_prompt_obj"]["messages"]), 1)
+        self.assertEqual(len(recorded["raw_response_obj"]["choices"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Move API call recording from `GameInteractionsRecorder` to a new `EventCallRecorder` that tracks calls per player
- Each player's requests are saved to separate files (e.g., `player_1.requests.json`) with metadata including game context, round count, and completion status
- Add `round_count` and `completed` fields to `interactions.json` meta for consistency
- Add abstract `get_players()` method to `GameMaster`

## Changes
- **`clemcore/clemgame/recorder.py`**: New `EventCallRecorder` class, removed request tracking from `GameInteractionsRecorder`
- **`clemcore/clemgame/callbacks/files.py`**: New `PlayerFileSaver` callback
- **`clemcore/clemgame/master.py`**: Added `get_players()` abstract method
- **`clemcore/cli.py`**: Register `PlayerFileSaver` callback
- **`tests/test_recorder.py`**: Unit tests for both recorder classes

## Breaking Changes
- `requests.json` is no longer generated (replaced by per-player `player_X.requests.json` files)
- `GameMaster` subclasses must implement `get_players()`

## Test plan
- [x] Unit tests for `GameInteractionsRecorder` metadata fields
- [x] Unit tests for `EventCallRecorder` (filtering, call recording, round tracking)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)