### PR TITLE
Fix callback ordering and handle None reward scores

### DIFF
--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -152,8 +152,9 @@ class GameMasterEnv(AECEnv):
         player_models = (self.options.get("player_models", None)
                          or [CustomResponseModel()] * self.game_benchmark.game_spec.players)
         self.game_master: DialogueGameMaster = self.game_benchmark.create_game_master(self.experiment, player_models)
-        self.game_master.setup(**self.game_instance)
-        self.callbacks.on_game_start(self.game_master, self.game_instance)
+        self.game_master.setup(**self.game_instance)  # this sets up the players
+        self.callbacks.on_game_start(self.game_master, self.game_instance)  # this might attach loggers
+        self.game_master.before_game()  # a hook for logging or other game-specific logic
         # Only after setup() the players are set
         self.player_by_agent_id = {f"player_{idx}": player
                                    for idx, player in enumerate(self.game_master.get_players())}

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -206,7 +206,7 @@ class GameMasterEnv(AECEnv):
 
         # Update current rewards and info for the current agent (response_score is returned in legacy master)
         self._cumulative_rewards[current_agent] = 0
-        self.rewards[current_agent] = info.get("turn_score", info.get("response_score", 0.))
+        self.rewards[current_agent] = info.get("turn_score", info.get("response_score", 0.)) or 0.  # when None
         self.infos[current_agent] = info
 
         # Inform callbacks about the game step results

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -220,7 +220,7 @@ class GameMasterEnv(AECEnv):
             for agent_id in self.agents:
                 # Note: we do not handle truncations separately yet, e.g., running out of turns
                 self.terminations[agent_id] = True
-                self.rewards[agent_id] = info.get("episode_score", 0.)
+                self.rewards[agent_id] = info.get("episode_score", 0.) or 0.  # when None
             self.callbacks.on_game_end(self.game_master, self.game_instance)
 
         # Collect and reset the rewards for all agents

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -105,6 +105,8 @@ class DialogueGameMaster(GameMaster):
         """
         self._on_setup(**kwargs)
         self._current_player = self.get_players()[self._current_player_idx]
+
+    def before_game(self):
         self._on_before_game()
         self.started = True
         self._on_before_round()

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -380,7 +380,7 @@ class DialogueGameMaster(GameMaster):
         self.log_next_round()  # add record entry for player turns
         self._on_before_round()
 
-    def get_turn_feedback(self):
+    def get_turn_feedback(self) -> str | None:
         """Optional textual feedback to be fed back to model (for playpen RL).
         Returns:
             A verbal feedback about the player's response given the context
@@ -388,7 +388,7 @@ class DialogueGameMaster(GameMaster):
         return None
 
     @abc.abstractmethod
-    def compute_turn_score(self):
+    def compute_turn_score(self) -> float:
         """Score response based on last context (for playpen RL)
         Returns:
             The performance score for a player's response given its last context
@@ -396,7 +396,7 @@ class DialogueGameMaster(GameMaster):
         pass
 
     @abc.abstractmethod
-    def compute_episode_score(self):
+    def compute_episode_score(self) -> float:
         """
         Returns:
             The performance of the agent over the whole episode

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -90,6 +90,10 @@ class GameMaster(EnvLike, GameEventSource):
         pass
 
     @abc.abstractmethod
+    def before_game(self):
+        pass
+
+    @abc.abstractmethod
     def is_done(self) -> bool:
         pass
 
@@ -210,6 +214,9 @@ class DialogueGameMaster(GameMaster):
         """
         self._on_setup(**kwargs)
         self._current_player = self.get_players()[self._current_player_idx]
+
+    @final
+    def before_game(self):
         self._on_before_game()
         self.started = True
         self._on_before_round()

--- a/clemcore/clemgame/runners/batchwise.py
+++ b/clemcore/clemgame/runners/batchwise.py
@@ -243,8 +243,9 @@ def __prepare_game_sessions(game_benchmark: GameBenchmark,
     for session_id, (experiment, game_instance) in enumerate(game_instance_iterator):
         try:
             game_master = game_benchmark.create_game_master(experiment, player_models)
-            callbacks.on_game_start(game_master, game_instance)
             game_master.setup(**game_instance)
+            callbacks.on_game_start(game_master, game_instance)
+            game_master.before_game()
             game_sessions.append(GameSession(session_id, game_master, game_instance))
         except Exception:  # continue with other instances if something goes wrong
             message = f"{game_benchmark.game_name}: Exception for instance {game_instance['game_id']} (but continue)"

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -399,7 +399,7 @@ Update Behavior:
                                  help="Create files always in current working directory.")
 
     run_parser = sub_parsers.add_parser("run", formatter_class=argparse.RawTextHelpFormatter)
-    run_parser.add_argument("-m", "--models", type=str, nargs="*",
+    run_parser.add_argument("-m", "--models", type=str, nargs="*", required=True,
                             help="""Assumes model names supported by the implemented backends.
 
       To run a specific game with a single player:

--- a/tests/test_pettingzoo_master.py
+++ b/tests/test_pettingzoo_master.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import MagicMock
+
+from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
+
+
+class GameMasterEnvStepRewardsTestCase(unittest.TestCase):
+    """Tests for GameMasterEnv.step() reward handling with None values."""
+
+    def _create_env_for_step(self):
+        """Helper to create GameMasterEnv ready for step() testing."""
+        mock_benchmark = MagicMock()
+        mock_benchmark.game_spec.game_name = "test_game"
+
+        mock_player = MagicMock()
+        mock_player.name = "Player 1"
+
+        mock_game_master = MagicMock()
+        mock_game_master.current_player = mock_player
+        mock_game_master.get_context_for.return_value = {"role": "user", "content": "test"}
+
+        env = GameMasterEnv(mock_benchmark)
+        env.game_master = mock_game_master
+        env.agents = ["player_0"]
+        env.possible_agents = ["player_0"]
+        env.player_by_agent_id = {"player_0": mock_player}
+        env.player_to_agent_id = {"Player 1": "player_0"}
+        env.agent_selection = "player_0"
+        env.terminations = {"player_0": False}
+        env.truncations = {"player_0": False}
+        env.rewards = {"player_0": 0.}
+        env._cumulative_rewards = {"player_0": 0.}
+        env.infos = {"player_0": {}}
+
+        return env, mock_game_master
+
+    def test_turn_score_none_defaults_to_zero(self):
+        """When turn_score is explicitly None, reward defaults to 0 (no TypeError)."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (False, {"turn_score": None})
+
+        env.step("action")  # Should not raise TypeError in _accumulate_rewards
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
+
+    def test_response_score_none_defaults_to_zero(self):
+        """When response_score is explicitly None (legacy), reward defaults to 0."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (False, {"response_score": None})
+
+        env.step("action")  # Should not raise TypeError in _accumulate_rewards
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
+
+    def test_episode_score_none_defaults_to_zero(self):
+        """When episode_score is explicitly None on done, reward defaults to 0."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (True, {"episode_score": None})
+
+        env.step("action")  # Should not raise TypeError in _accumulate_rewards
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
+
+    def test_valid_turn_score_preserved(self):
+        """When turn_score has a valid value, it is accumulated."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (False, {"turn_score": 0.5})
+
+        env.step("action")
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.5)
+
+    def test_valid_episode_score_preserved(self):
+        """When episode_score has a valid value on done, it is accumulated."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (True, {"episode_score": 1.0})
+
+        env.step("action")
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Extract `before_game()` from `setup()` to fix callback ordering, allowing loggers to be attached before game-specific setup runs
- Handle `None` values for `turn_score`, `response_score`, and `episode_score` in `GameMasterEnv` rewards to prevent `TypeError`
- Add missing return type hints for `get_turn_feedback`, `compute_turn_score`, `compute_episode_score`
- Make `-m` option required for `clem run` CLI command

## Test plan

- [x] New unit tests added for None reward handling (`test_pettingzoo_master.py`)
- [x] All new tests pass
- [x] Manual testing with game execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)