### PR TITLE
 Add reward_func / feedback_func to GameMasterEnv, grounded in GameState

### DIFF
--- a/clemcore/clemgame/benchmark.py
+++ b/clemcore/clemgame/benchmark.py
@@ -4,19 +4,15 @@ import inspect
 import logging
 import os
 import sys
-from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, ContextManager, Callable, Optional
 from tqdm import tqdm
 
 from clemcore import backends
-from clemcore.clemgame import GameBenchmarkCallbackList, GameBenchmarkCallback
 from clemcore.clemgame.master import GameMaster
 from clemcore.clemgame.metrics import GameScorer
 from clemcore.clemgame.registry import GameSpec
 from clemcore.clemgame.resources import GameResourceLocator, load_json
-from clemcore.clemgame.instances import GameInstanceIterator
 
 module_logger = logging.getLogger(__name__)
 stdout_logger = logging.getLogger("clemcore.run")
@@ -46,9 +42,9 @@ class GameBenchmark(GameResourceLocator):
         """
         super().__init__(game_spec.game_name, game_spec.game_path)
         self.game_spec = game_spec
-        self._extra_modules: List[str] = []  # additional modules loaded during load_from_spec
+        self._extra_modules: list[str] = []  # additional modules loaded during load_from_spec
 
-    def set_extra_modules(self, extra_modules: List[str]):
+    def set_extra_modules(self, extra_modules: list[str]):
         self._extra_modules = extra_modules
 
     def close(self):
@@ -97,7 +93,7 @@ class GameBenchmark(GameResourceLocator):
             stdout_logger.error(
                 f"{self.game_name}: '{error_count}' exceptions occurred: See clembench.log for details.")
 
-    def create_game_master(self, experiment: Dict, player_models: List[backends.Model]) -> GameMaster:
+    def create_game_master(self, experiment: dict, player_models: list[backends.Model]) -> GameMaster:
         """Create a game-specific GameMaster subclass instance to run the game with.
         Must be implemented!
         Args:
@@ -108,7 +104,7 @@ class GameBenchmark(GameResourceLocator):
         """
         raise NotImplementedError()
 
-    def create_game_scorer(self, experiment: Dict, game_instance: Dict) -> GameScorer:
+    def create_game_scorer(self, experiment: dict, game_instance: dict) -> GameScorer:
         """Create a game-specific GameScorer subclass instance to score benchmark records with.
         Must be implemented!
         Args:

--- a/clemcore/clemgame/envs/openenv/server/app.py
+++ b/clemcore/clemgame/envs/openenv/server/app.py
@@ -30,6 +30,7 @@ def create_clemv_app(
         gen_args: Optional[Dict[str, Any]] = None,
         callbacks: Optional[GameBenchmarkCallbackList] = None,
         reward_func: Optional[Callable[[dict, str, GameState, dict], float]] = None,
+        feedback_func: Optional[Callable[[dict, str, GameState, dict], str | None]] = None,
         results_dir: Optional[str] = None,
         run_id: Optional[str] = None
 ):
@@ -66,6 +67,7 @@ def create_clemv_app(
                               env_agents=env_agents,
                               gen_args=gen_args,
                               callbacks=callbacks,
-                              reward_func=reward_func
+                              reward_func=reward_func,
+                              feedback_func=feedback_func
                               )
     return create_app(env, ClemGameAction, ClemGameObservation, env_name="clem_env")

--- a/clemcore/clemgame/envs/openenv/server/app.py
+++ b/clemcore/clemgame/envs/openenv/server/app.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional, Any
+from typing import Callable, Dict, Optional, Any
 
 from openenv_core.env_server import create_app
 
@@ -8,6 +8,7 @@ from clemcore.clemgame.callbacks import episode_results_folder_callbacks
 from clemcore.clemgame.callbacks.base import GameBenchmarkCallbackList
 from clemcore.clemgame.envs.openenv.models import ClemGameAction, ClemGameObservation
 from clemcore.clemgame.envs.openenv.server.environment import ClemGameEnvironment
+from clemcore.clemgame.master import GameState
 
 CLEMV_GAME = os.getenv("CLEMV_GAME")
 CLEMV_GAME_SPLIT = os.getenv("CLEMV_GAME_SPLIT")
@@ -28,6 +29,7 @@ def create_clemv_app(
         single_pass: bool = CLEMV_SINGLE_PASS,
         gen_args: Optional[Dict[str, Any]] = None,
         callbacks: Optional[GameBenchmarkCallbackList] = None,
+        reward_func: Optional[Callable[[dict, str, GameState, dict], float]] = None,
         results_dir: Optional[str] = None,
         run_id: Optional[str] = None
 ):
@@ -63,6 +65,7 @@ def create_clemv_app(
                               learner_agent=learner_agent,
                               env_agents=env_agents,
                               gen_args=gen_args,
-                              callbacks=callbacks
+                              callbacks=callbacks,
+                              reward_func=reward_func
                               )
     return create_app(env, ClemGameAction, ClemGameObservation, env_name="clem_env")

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -27,7 +27,8 @@ class ClemGameEnvironment(Environment):
                  env_agents: Dict[str, str] = None,
                  gen_args: Dict[str, Any] = None,
                  callbacks: GameBenchmarkCallbackList = None,
-                 reward_func: Callable[[dict, str, GameState, dict], float] = None
+                 reward_func: Callable[[dict, str, GameState, dict], float] = None,
+                 feedback_func: Callable[[dict, str, GameState, dict], str | None] = None
                  ):
         super().__init__()
         module_logger.info("Initialize ClemGameEnvironment: "
@@ -62,7 +63,8 @@ class ClemGameEnvironment(Environment):
                                  learner_agent=learner_agent,
                                  env_agents=env_agents,
                                  callbacks=callbacks,
-                                 reward_func=reward_func
+                                 reward_func=reward_func,
+                                 feedback_func=feedback_func
                                  )
 
     def close(self):

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import asdict
-from typing import Dict, Any
+from typing import Callable, Dict, Any
 
 from datasets import load_dataset
 from openenv_core import Environment
@@ -9,6 +9,7 @@ from clemcore.backends import load_models
 from clemcore.clemgame.callbacks.base import GameBenchmarkCallbackList
 from clemcore.clemgame.envs.openenv.models import ClemGameState, ClemGameObservation, ClemGameAction
 from clemcore.clemgame.envs.pettingzoo import gym_env, check_agent_mapping_for_training
+from clemcore.clemgame.master import GameState
 from clemcore.clemgame.registry import GameRegistry
 from clemcore.clemgame.instances import to_instance_filter
 
@@ -25,7 +26,8 @@ class ClemGameEnvironment(Environment):
                  learner_agent: str = "player_0",
                  env_agents: Dict[str, str] = None,
                  gen_args: Dict[str, Any] = None,
-                 callbacks: GameBenchmarkCallbackList = None
+                 callbacks: GameBenchmarkCallbackList = None,
+                 reward_func: Callable[[dict, str, GameState, dict], float] = None
                  ):
         super().__init__()
         module_logger.info("Initialize ClemGameEnvironment: "
@@ -59,7 +61,8 @@ class ClemGameEnvironment(Environment):
                                  single_pass=single_pass,
                                  learner_agent=learner_agent,
                                  env_agents=env_agents,
-                                 callbacks=callbacks
+                                 callbacks=callbacks,
+                                 reward_func=reward_func
                                  )
 
     def close(self):

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -199,7 +199,7 @@ class DialogueGameMaster(GameMaster):
         # Consume the initial_prompt (if set) now that we've committed to this turn
         self.initial_prompt_for_player.pop(self.current_player.name, None)
 
-        self.info["response_feedback"] = self.get_response_feedback(response, context)
+
 
         # todo: it seems we should change the order here: Parse should come first, and then validate.
         # While parse might throw a parsing (format error) validate would check solely for satisfied game rules.
@@ -262,19 +262,6 @@ class DialogueGameMaster(GameMaster):
     def __prepare_next_round(self):
         self.log_next_round()  # add record entry for player turns
         self._on_before_round()
-
-    def get_response_feedback(self, response: str, context: dict) -> str | None:
-        """Optional qualitative feedback on the player's response (for playpen RL).
-
-        Override to provide language feedback that can be fed back to the model during training.
-
-        Args:
-            response: The response of the current player.
-            context: The context given to the current player to generate the response for.
-        Returns:
-            A verbal feedback string, or None if no feedback is provided.
-        """
-        return None
 
     @abc.abstractmethod
     def _on_valid_player_response(self, player: Player, parsed_response: str):

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -199,8 +199,6 @@ class DialogueGameMaster(GameMaster):
         # Consume the initial_prompt (if set) now that we've committed to this turn
         self.initial_prompt_for_player.pop(self.current_player.name, None)
 
-
-
         # todo: it seems we should change the order here: Parse should come first, and then validate.
         # While parse might throw a parsing (format error) validate would check solely for satisfied game rules.
         # Note: this would allow to cut off too long responses (during parse) and to only validate on the cut off piece.

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -343,19 +343,6 @@ class DialogueGameMaster(GameMaster):
         """
         return response
 
-    @abc.abstractmethod
-    def _does_game_proceed(self) -> bool:
-        """Check if game should proceed.
-
-        Mandatory override.
-
-        This method is used to determine if a game should continue or be stopped. Both successful completion of the game
-        and game-ending failures should lead to this method returning False.
-        Returns:
-            A bool, True if game continues, False if game should stop.
-        """
-        pass
-
     def _on_before_round(self):
         """Executed in the play loop before a new round of gameplay starts.
 

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -121,9 +121,6 @@ class DialogueGameMaster(GameMaster):
         """
         pass
 
-    def get_game_state(self):
-        return None
-
     def set_initial_prompt_for(self, player: Player, content: str, **extras):
         """
         Set the initial prompt for the specified Player. The prompt will be prefixed to the player's next turn.

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -210,10 +210,6 @@ class DialogueGameMaster(GameMaster):
     def __setstate__(self, state):
         self.__dict__.update(state)
 
-    @property
-    def game_state(self):
-        return None
-
     @final
     def get_players(self) -> list[Player]:
         """Get a list of the players.

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -388,7 +388,6 @@ class DialogueGameMaster(GameMaster):
         except GameError as error:
             self._on_game_error(error)
 
-        self.info["turn_score"] = self.compute_turn_score()
         self.info["turn_feedback"] = self.get_turn_feedback()
 
         # determine if the current player should pass the turn to the next player or get another turn:
@@ -403,7 +402,6 @@ class DialogueGameMaster(GameMaster):
         if done:
             self._on_after_game()
             self.log_game_end()
-            self.info["episode_score"] = self.compute_episode_score()
         elif self._start_next_round():  # prepare next round only when game has not ended yet
             self.__prepare_next_round()
 
@@ -453,22 +451,6 @@ class DialogueGameMaster(GameMaster):
             A verbal feedback about the player's response given the context
         """
         return None
-
-    @abc.abstractmethod
-    def compute_turn_score(self) -> float:
-        """Score response based on last context (for playpen RL)
-        Returns:
-            The performance score for a player's response given its last context
-        """
-        pass
-
-    @abc.abstractmethod
-    def compute_episode_score(self) -> float:
-        """
-        Returns:
-            The performance of the agent over the whole episode
-        """
-        pass
 
     @abc.abstractmethod
     def _advance_game(self, player: Player, parsed_response: str):

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -388,7 +388,6 @@ class DialogueGameMaster(GameMaster):
         except GameError as error:
             self._on_game_error(error)
 
-        self.info["turn_feedback"] = self.get_turn_feedback()
 
         # determine if the current player should pass the turn to the next player or get another turn:
         if self._should_pass_turn():  # True = move on to next player
@@ -444,13 +443,6 @@ class DialogueGameMaster(GameMaster):
     def __prepare_next_round(self):
         self.log_next_round()  # add record entry for player turns
         self._on_before_round()
-
-    def get_turn_feedback(self) -> str | None:
-        """Optional textual feedback to be fed back to model (for playpen RL).
-        Returns:
-            A verbal feedback about the player's response given the context
-        """
-        return None
 
     @abc.abstractmethod
     def _advance_game(self, player: Player, parsed_response: str):

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -73,6 +73,28 @@ class GameMaster(GameEventSource):
         self.game_resources = GameResourceLocator(game_spec.game_name, game_spec.game_path)
         self._current_player: Player | None = None
 
+    def _does_game_proceed(self) -> bool:
+        """Determine whether the game should continue.
+
+        The default implementation checks ``self.state.outcome``: the game proceeds
+        as long as the outcome is ``Outcome.RUNNING`` (i.e., not terminal).
+
+        To end the game, call one of the state transition methods in ``_advance_game``
+        or error hooks::
+
+            self.state.succeed()   # player achieved the goal
+            self.state.failed()    # player lost but game rules were followed
+            self.state.abort()     # unrecoverable error (e.g., repeated parse failures)
+
+        Subclasses may override this method for custom termination logic (e.g., turn
+        limits, external conditions). When overriding, ensure consistency with
+        ``self.state.outcome`` if both mechanisms are used.
+
+        Returns:
+            True if the game should continue, False if it should stop.
+        """
+        return not self.state.outcome.is_terminal
+
     @property
     def current_player(self) -> Player:
         """Get the current player whose turn it is.
@@ -485,19 +507,6 @@ class DialogueGameMaster(GameMaster):
             The parsed response
         Raises:
             ParseError: If the message format is incorrect or the message cannot be properly parsed by the game master.
-        """
-        pass
-
-    @abc.abstractmethod
-    def _does_game_proceed(self) -> bool:
-        """Check if game should proceed.
-
-        Mandatory override.
-
-        This method is used to determine if a game should continue or be stopped. Both successful completion of the game
-        and game-ending failures should lead to this method returning False.
-        Returns:
-            A bool, True if game continues, False if game should stop.
         """
         pass
 

--- a/tests/test_pettingzoo_api.py
+++ b/tests/test_pettingzoo_api.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 from pettingzoo.test import api_test
 
-from clemcore.clemgame import env
+from clemcore.clemgame import env, gym_env
 
 
 @pytest.mark.integration
@@ -16,6 +16,79 @@ class PettingzooTestCase(unittest.TestCase):
 
     def test_api(self):
         api_test(env("taboo"), num_cycles=1000, verbose_progress=False)
+
+
+@pytest.mark.integration
+class WordleRewardFuncTestCase(unittest.TestCase):
+    """Integration tests for reward_func with the real Wordle game.
+
+    Requires the Wordle game to be installed (clembench repository on the path).
+
+    Note: Wordle uses a legacy WordleGameState dataclass (success/failure/aborted booleans)
+    rather than the new GameState with Outcome enum, so a game-specific reward_func is needed.
+    """
+
+    def _wordle_reward(self, observation, action, state, info):
+        """Wordle-specific reward: 1 on success, -1 on abort, 0 otherwise."""
+        if state.success:
+            return 1.
+        if state.aborted:
+            return -1.
+        return 0.
+
+    def _make_guess(self, word):
+        """Format a guess response in the Wordle protocol."""
+        return f"explanation: test\nguess: {word}"
+
+    def _get_target_word(self, game_env):
+        """Peek at the target word from the game master state after reset."""
+        return game_env.env.unwrapped.game_master.state.target_word
+
+    def test_correct_guess_yields_reward_one(self):
+        """Immediately guessing the target word should give reward 1."""
+        game_env = gym_env("wordle", reward_func=self._wordle_reward)
+        game_env.reset()
+        target_word = self._get_target_word(game_env)
+
+        _, reward, done, _, _ = game_env.step(self._make_guess(target_word))
+
+        self.assertTrue(done)
+        self.assertEqual(reward, 1.)
+        game_env.close()
+
+    def test_exhaust_turns_yields_reward_zero(self):
+        """Exhausting all turns without guessing correctly should give reward 0."""
+        game_env = gym_env("wordle", reward_func=self._wordle_reward)
+        game_env.reset()
+        target_word = self._get_target_word(game_env)
+        # Pick a valid word that is definitely not the target
+        wrong_word = "apple" if target_word != "apple" else "beach"
+
+        reward, done = 0., False
+        while not done:
+            _, reward, done, _, _ = game_env.step(self._make_guess(wrong_word))
+
+        self.assertEqual(reward, 0.)
+        game_env.close()
+
+    def test_reward_func_receives_wordle_state(self):
+        """The state passed to reward_func should be WordleGameState with target_word."""
+        states_seen = []
+
+        def recording_reward(observation, action, state, info):
+            states_seen.append(state)
+            return 0.
+
+        game_env = gym_env("wordle", reward_func=recording_reward)
+        game_env.reset()
+        target_word = self._get_target_word(game_env)
+
+        game_env.step(self._make_guess(target_word))
+
+        self.assertTrue(len(states_seen) > 0)
+        self.assertEqual(states_seen[-1].target_word, target_word)
+        self.assertTrue(states_seen[-1].success)
+        game_env.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_pettingzoo_master.py
+++ b/tests/test_pettingzoo_master.py
@@ -2,12 +2,13 @@ import unittest
 from unittest.mock import MagicMock
 
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
+from clemcore.clemgame.master import GameState, Outcome
 
 
 class GameMasterEnvStepRewardsTestCase(unittest.TestCase):
-    """Tests for GameMasterEnv.step() reward handling with None values."""
+    """Tests for GameMasterEnv.step() reward handling."""
 
-    def _create_env_for_step(self):
+    def _create_env_for_step(self, reward_func=None):
         """Helper to create GameMasterEnv ready for step() testing."""
         mock_benchmark = MagicMock()
         mock_benchmark.game_spec.game_name = "test_game"
@@ -18,8 +19,9 @@ class GameMasterEnvStepRewardsTestCase(unittest.TestCase):
         mock_game_master = MagicMock()
         mock_game_master.current_player = mock_player
         mock_game_master.get_context_for.return_value = {"role": "user", "content": "test"}
+        mock_game_master.state = GameState()  # real GameState so outcome comparisons work
 
-        env = GameMasterEnv(mock_benchmark)
+        env = GameMasterEnv(mock_benchmark, reward_func=reward_func)
         env.game_master = mock_game_master
         env.agents = ["player_0"]
         env.possible_agents = ["player_0"]
@@ -34,50 +36,89 @@ class GameMasterEnvStepRewardsTestCase(unittest.TestCase):
 
         return env, mock_game_master
 
-    def test_turn_score_none_defaults_to_zero(self):
-        """When turn_score is explicitly None, reward defaults to 0 (no TypeError)."""
+    def test_default_reward_running_is_zero(self):
+        """Default reward is 0 for non-terminal (RUNNING) steps."""
         env, mock_gm = self._create_env_for_step()
-        mock_gm.step.return_value = (False, {"turn_score": None})
-
-        env.step("action")  # Should not raise TypeError in _accumulate_rewards
-
-        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
-
-    def test_response_score_none_defaults_to_zero(self):
-        """When response_score is explicitly None (legacy), reward defaults to 0."""
-        env, mock_gm = self._create_env_for_step()
-        mock_gm.step.return_value = (False, {"response_score": None})
-
-        env.step("action")  # Should not raise TypeError in _accumulate_rewards
-
-        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
-
-    def test_episode_score_none_defaults_to_zero(self):
-        """When episode_score is explicitly None on done, reward defaults to 0."""
-        env, mock_gm = self._create_env_for_step()
-        mock_gm.step.return_value = (True, {"episode_score": None})
-
-        env.step("action")  # Should not raise TypeError in _accumulate_rewards
-
-        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
-
-    def test_valid_turn_score_preserved(self):
-        """When turn_score has a valid value, it is accumulated."""
-        env, mock_gm = self._create_env_for_step()
-        mock_gm.step.return_value = (False, {"turn_score": 0.5})
+        mock_gm.step.return_value = (False, {})
+        # state.outcome stays RUNNING (default)
 
         env.step("action")
 
-        self.assertEqual(env._cumulative_rewards["player_0"], 0.5)
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
 
-    def test_valid_episode_score_preserved(self):
-        """When episode_score has a valid value on done, it is accumulated."""
+    def test_default_reward_success_is_one(self):
+        """Default reward is 1 when game ends with SUCCESS."""
         env, mock_gm = self._create_env_for_step()
-        mock_gm.step.return_value = (True, {"episode_score": 1.0})
+        mock_gm.step.return_value = (True, {})
+        mock_gm.state.succeed()
 
         env.step("action")
 
-        self.assertEqual(env._cumulative_rewards["player_0"], 1.0)
+        self.assertEqual(env._cumulative_rewards["player_0"], 1.)
+
+    def test_default_reward_failure_is_zero(self):
+        """Default reward is 0 when game ends with FAILURE."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (True, {})
+        mock_gm.state.failed()
+
+        env.step("action")
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.)
+
+    def test_default_reward_aborted_is_minus_one(self):
+        """Default reward is -1 when game ends with ABORTED."""
+        env, mock_gm = self._create_env_for_step()
+        mock_gm.step.return_value = (True, {})
+        mock_gm.state.abort()
+
+        env.step("action")
+
+        self.assertEqual(env._cumulative_rewards["player_0"], -1.)
+
+    def test_custom_reward_func_is_called(self):
+        """A custom reward_func receives (observation, action, state, info) and its return value is used."""
+        recorded = {}
+
+        def my_reward(observation, action, state, info):
+            recorded["observation"] = observation
+            recorded["action"] = action
+            recorded["state"] = state
+            recorded["info"] = info
+            return 0.42
+
+        env, mock_gm = self._create_env_for_step(reward_func=my_reward)
+        mock_gm.step.return_value = (False, {"some_key": "val"})
+
+        env.step("my_action")
+
+        self.assertEqual(env._cumulative_rewards["player_0"], 0.42)
+        self.assertEqual(recorded["action"], "my_action")
+        self.assertIs(recorded["state"], mock_gm.state)
+        self.assertEqual(recorded["info"], {"some_key": "val"})
+
+    def test_custom_reward_func_can_read_game_state_fields(self):
+        """Custom reward_func can access game-specific state fields (e.g. letter_matches)."""
+        class WordleState(GameState):
+            def __init__(self):
+                super().__init__()
+                self.letter_matches = 3
+                self.word_length = 5
+
+        def wordle_reward(observation, action, state, info):
+            if state.outcome == Outcome.SUCCESS:
+                return 1.
+            if state.outcome == Outcome.ABORTED:
+                return -1.
+            return state.letter_matches / state.word_length
+
+        env, mock_gm = self._create_env_for_step(reward_func=wordle_reward)
+        mock_gm.state = WordleState()
+        mock_gm.step.return_value = (False, {})
+
+        env.step("crane")
+
+        self.assertAlmostEqual(env._cumulative_rewards["player_0"], 0.6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

### GameState
- Introduce `Outcome` enum (`RUNNING`, `SUCCESS`, `FAILURE`, `ABORTED`) with an `is_terminal` property
- Add `GameState` class with transition methods `succeed()`, `failed()`, `abort()`
- Move `_does_game_proceed()` from abstract in `DialogueGameMaster` to a concrete default on `GameMaster`, implemented via `self.state.outcome`
- Remove the now-obsolete `game_state` property and `get_game_state()` from `DialogueGameMaster`

### reward_func / feedback_func
- Add `reward_func(observation, action, state, info) -> float` to `GameMasterEnv`; default maps `Outcome` → `1.0` / `0.0` / `-1.0` / `0.0`
- Add `feedback_func(observation, action, state, info) -> str | None` to `GameMasterEnv`; result stored in `info["turn_feedback"]` for training loop consumption
- Remove `compute_turn_score` / `compute_episode_score` abstract methods from `DialogueGameMaster` (new) — reward is now the env's responsibility
- Remove `compute_response_score` / `compute_episode_score` / `get_response_feedback` / `get_turn_feedback` from legacy `DialogueGameMaster` — no game implementations used these
- Thread `reward_func` and `feedback_func` through `env()`, `gym_env()`, `ClemGameEnvironment`, and `create_clemv_app()`
- Fix `observation_space()` / `action_space()` to fall back to the default space before `reset()` is called (was previously a `KeyError`)

## Motivation

These two changes form a single design: a structured `GameState` provides the signal that `reward_func` consumes. The original PR already named *"Foundation for deriving reward signals"* as a goal — this completes it.

Reward computation is moved out of `GameMaster` entirely. Game-specific shaping is supported by subclassing `GameState` to carry additional fields (e.g., letter matches in Wordle) and reading them in a custom `reward_func`.

**Games should still provide helper functions for game-specific reward calculation, which callers pass to env() / gym_env() as reward_func.**

## Breaking changes

- `_does_game_proceed()` is no longer abstract. Games that still override it work unchanged. Games that previously only implemented it to track `outcome` can now call `self.state.succeed()` / `failed()` / `abort()` instead and remove the override.
- `compute_turn_score`, `compute_episode_score`, `compute_response_score`, `get_turn_feedback`, `get_response_feedback` are removed. Any game implementations of these methods will be silently ignored — move reward logic to a `reward_func` passed to `env()` / `gym_env()`.

## Test plan
- [x] Wordle integration tests added (`test_pettingzoo_api.py`)
- [x] PettingZoo master tests updated for `reward_func` / `feedback_func` (`test_pettingzoo_master.py`)
- [x] Verify existing games (Wordle, Taboo) still run correctly end-to-end
- [x] Test `reward_func` / `feedback_func` passthrough via `create_clemv_app()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)