### PR TITLE
fix: compute_scores not filtering interaction files properly when a model's name includes that of a game

### DIFF
--- a/clemcore/clemgame/benchmark.py
+++ b/clemcore/clemgame/benchmark.py
@@ -68,10 +68,10 @@ class GameBenchmark(GameResourceLocator):
         """
         results_root = results_dir
         filter_games = [self.game_name]
-        interaction_files = glob.glob(os.path.join(results_root, '**', 'interactions.json'), recursive=True)
-        if filter_games:
-            interaction_files = [interaction_file for interaction_file in interaction_files
-                                 if any(game_name in interaction_file for game_name in filter_games)]
+        interaction_files = [
+            f for f in glob.glob(os.path.join(results_root, '**', 'interactions.json'), recursive=True)
+            if Path(f).parents[2].name in filter_games
+        ]
         stdout_logger.info(f"Found {len(interaction_files)} interaction files to score. "
                            f"Games: {filter_games if filter_games else 'all'}")
         error_count = 0

--- a/clemcore/clemgame/benchmark.py
+++ b/clemcore/clemgame/benchmark.py
@@ -70,7 +70,7 @@ class GameBenchmark(GameResourceLocator):
         filter_games = [self.game_name]
         interaction_files = [
             f for f in glob.glob(os.path.join(results_root, '**', 'interactions.json'), recursive=True)
-            if Path(f).parents[2].name in filter_games
+            if any(game_name in Path(f).parts for game_name in filter_games)
         ]
         stdout_logger.info(f"Found {len(interaction_files)} interaction files to score. "
                            f"Games: {filter_games if filter_games else 'all'}")


### PR DESCRIPTION
Since I fine-tuned a model on a single game, i happened to include the name of a game within that of the model's entry in the model_registry.json file (model name: vllm-Qwen3-4B-Instruct-2507-**imagegame**-v11).

This led to an error when scoring the models because when running _clem score -g imagegame_, it was taking all the interaction files from every game on which I ran this model (i just wanted imagegame instances, but was taking also adventuregame, taboo,.. and others). 
This led the ImageGameScorer to break because we were not feeding it just imagegame's interaction files.

The same error happens also naming models with privateshared and referencegame and the respective GameScorers.

I propose a fix where we take interactions.json files only when the game_name from the -g argument matches with that of the game folder in the clemcore's generated directory tree, so that the model's name does not affect the scoring process.
Also, since filter_games does not seem to be None in any case I removed the check.