### PR TITLE
Update openenv integration for openenv-core 0.2.1

### DIFF
--- a/clemcore/clemgame/envs/openenv/client.py
+++ b/clemcore/clemgame/envs/openenv/client.py
@@ -1,10 +1,10 @@
-from openenv_core.http_env_client import HTTPEnvClient
-from openenv_core.client_types import StepResult
+from openenv.core import EnvClient
+from openenv.core.client_types import StepResult
 
 from clemcore.clemgame.envs.openenv.models import ClemGameAction, ClemGameObservation, ClemGameState
 
 
-class ClemGameEnv(HTTPEnvClient[ClemGameAction, ClemGameObservation]):
+class ClemGameEnv(EnvClient[ClemGameAction, ClemGameObservation, ClemGameState]):
     def _step_payload(self, action: ClemGameAction) -> dict:
         """Convert action to JSON"""
         return {"response": action.response}

--- a/clemcore/clemgame/envs/openenv/models.py
+++ b/clemcore/clemgame/envs/openenv/models.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from openenv_core.env_server import Action, Observation, State
+from openenv.core import Action, Observation, State
 
 
 @dataclass

--- a/clemcore/clemgame/envs/openenv/models.py
+++ b/clemcore/clemgame/envs/openenv/models.py
@@ -1,20 +1,16 @@
-from dataclasses import dataclass
 from typing import Dict, Optional
 
 from openenv.core import Action, Observation, State
 
 
-@dataclass
 class ClemGameAction(Action):
     response: str
 
 
-@dataclass
 class ClemGameObservation(Observation):
     context: Dict
 
 
-@dataclass
 class ClemGameState(State):
     game_name: Optional[str] = None
     episode_count: int = 0

--- a/clemcore/clemgame/envs/openenv/server/app.py
+++ b/clemcore/clemgame/envs/openenv/server/app.py
@@ -1,7 +1,7 @@
 import os
 from typing import Callable, Dict, Optional, Any
 
-from openenv_core.env_server import create_app
+from openenv.core import create_app
 
 from clemcore.utils.string_utils import read_query_string
 from clemcore.clemgame.callbacks import episode_results_folder_callbacks
@@ -70,4 +70,4 @@ def create_clemv_app(
                               reward_func=reward_func,
                               feedback_func=feedback_func
                               )
-    return create_app(env, ClemGameAction, ClemGameObservation, env_name="clem_env")
+    return create_app(lambda: env, ClemGameAction, ClemGameObservation, env_name="clem_env")

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 from typing import Callable, Dict, Any
 
 from datasets import load_dataset
-from openenv_core import Environment
+from openenv.core import Environment
 
 from clemcore.backends import load_models
 from clemcore.clemgame.callbacks.base import GameBenchmarkCallbackList
@@ -71,7 +71,7 @@ class ClemGameEnvironment(Environment):
         module_logger.info(f"Close ClemGameEnvironment {self._state.game_name}")
         self._game_env.close()
 
-    def reset(self) -> ClemGameObservation:
+    def reset(self, seed=None, episode_id=None, **kwargs) -> ClemGameObservation:
         observation, info = self._game_env.reset()
         self._state.step_count = 0
         self._state.episode_count += 1
@@ -79,7 +79,7 @@ class ClemGameEnvironment(Environment):
         module_logger.info(f"Reset ClemGameEnvironment {self._state.game_name} for episode {self._state.episode_id}")
         return ClemGameObservation(context=observation)
 
-    def step(self, action: ClemGameAction) -> ClemGameObservation:
+    def step(self, action: ClemGameAction, timeout_s=None, **kwargs) -> ClemGameObservation:
         if module_logger.isEnabledFor(logging.DEBUG):
             module_logger.debug(f"Step ClemGameEnvironment with action={asdict(action)}")
         observation, reward, done, truncated, info = self._game_env.step(action.response)

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import asdict
 from typing import Callable, Dict, Any
 
 from datasets import load_dataset
@@ -81,7 +80,7 @@ class ClemGameEnvironment(Environment):
 
     def step(self, action: ClemGameAction, timeout_s=None, **kwargs) -> ClemGameObservation:
         if module_logger.isEnabledFor(logging.DEBUG):
-            module_logger.debug(f"Step ClemGameEnvironment with action={asdict(action)}")
+            module_logger.debug(f"Step ClemGameEnvironment with action={action.model_dump()}")
         observation, reward, done, truncated, info = self._game_env.step(action.response)
         if module_logger.isEnabledFor(logging.DEBUG):
             print(f"Step ClemGameEnvironment result is "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "ordered-set>=4.1.0,<5.0.0", # transcripts
     "markdown>=3.8.0,<4.0.0", # transcripts
     "pettingzoo>=1.25.0,<2.0.0", # to wrap games as pettingzoo or gymnasium environments
-    "openenv-core~=0.1.1", # to serve games as openenv server
+    "openenv-core~=0.2.1", # to serve games as openenv server
     "datasets>=4.4.0,<5.0.0" # to load playpen-data for openenv server
 ]
 


### PR DESCRIPTION
## Summary

- Replace deprecated `openenv_core` imports with `openenv.core` across all openenv modules
- Replace `HTTPEnvClient` with `EnvClient` (renamed; now WebSocket-based; generic now takes 3 type params: action, observation, state)
- Pass env factory callable `lambda: env` to `create_app` instead of an instance (API change)
- Update `reset` and `step` signatures in `ClemGameEnvironment` to match the new `Environment` base class (`seed`, `episode_id`, `timeout_s`, `**kwargs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)