### PR TITLE
Replace GameInstanceIterator with GameInstances eager collection

### DIFF
--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -8,7 +8,7 @@ from clemcore.clemgame.envs.openenv.models import ClemGameObservation, ClemGameA
 from clemcore.clemgame.envs.pettingzoo import env, gym_env
 from clemcore.clemgame.errors import GameError, ParseError, RuleViolationError, ResponseError, ProtocolError, \
     NotApplicableError
-from clemcore.clemgame.instances import GameInstanceGenerator, GameInstanceIterator
+from clemcore.clemgame.instances import GameInstanceGenerator, GameInstances
 from clemcore.clemgame.resources import GameResourceLocator
 from clemcore.clemgame.master import GameMaster, DialogueGameMaster, Player
 from clemcore.clemgame.metrics import GameScorer
@@ -33,7 +33,7 @@ __all__ = [
     "GameScorer",
     "GameSpec",
     "GameRegistry",
-    "GameInstanceIterator",
+    "GameInstances",
     "GameInstanceGenerator",
     "episode_results_folder_callbacks",
     "EpochResultsFolder",

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -39,11 +39,11 @@ class ClemGameEnvironment(Environment):
         game_spec = GameRegistry.from_directories_and_cwd_files().get_game_spec(game_name)
         check_agent_mapping_for_training(game_spec, {learner_agent: "learner", **env_agents})
 
-        game_instance_filter = None  # use all the default game instances of the game
+        instances_filter = None  # use all the default game instances of the game
         if game_instance_split:
             # We only use the training instances so that we can properly evaluate on the validation set later
             dataset = load_dataset("colab-potsdam/playpen-data", "instances", split=game_instance_split)
-            game_instance_filter = to_instance_filter(dataset)
+            instances_filter = to_instance_filter(dataset)
 
         # Finally, load the opponent models, which can take a long time for large models
         if game_spec.is_multi_player():  # if single_player env_agents should be None; or check has failed above
@@ -57,7 +57,7 @@ class ClemGameEnvironment(Environment):
         self._game_name = game_name
         self._state = ClemGameState(game_name=game_name, episode_id="episode_0", step_count=0, episode_count=0)
         self._game_env = gym_env(game_name,
-                                 game_instance_filter=game_instance_filter,
+                                 instances_filter=instances_filter,
                                  single_pass=single_pass,
                                  learner_agent=learner_agent,
                                  env_agents=env_agents,

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -5,7 +5,7 @@ import gymnasium
 from clemcore.backends.model_registry import CustomResponseModel
 from clemcore.clemgame.callbacks.base import GameBenchmarkCallbackList, GameStep
 from clemcore.clemgame.registry import GameRegistry
-from clemcore.clemgame.instances import GameInstanceIterator
+from clemcore.clemgame.instances import GameInstances
 from clemcore.clemgame.benchmark import GameBenchmark
 from clemcore.clemgame.master import GameMaster, GameState, Outcome
 from clemcore.clemgame.envs.pettingzoo.wrappers import (
@@ -24,7 +24,7 @@ from pettingzoo.utils.env import AgentID, ObsType, ActionType
 
 def gym_env(game_name: str,
             *,
-            game_instance_filter: Callable[[str, str], list[int]] | None = None,
+            instances_filter: Callable[[dict], bool] | None = None,
             single_pass: bool = False,
             learner_agent: AgentID = "player_0",
             env_agents: dict[AgentID, EnvAgent] | None = None,
@@ -48,7 +48,8 @@ def gym_env(game_name: str,
 
     Args:
         game_name: The name of the clem-game to wrap as a PZ env
-        game_instance_filter: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
+        instances_filter: A condition to filter the list of dicts with "experiment" and "game_instance" keys.
+            If the filter is None, then all game instances will be used.
         single_pass: Whether to run through the game instances only once or multiple times.
         learner_agent: the agent id of the learner agent (e.g. player_0)
         env_agents: a mapping from agent ids to Models or Callables (e.g. {player_1: gpt5} or {player_1: lambda obs: "action"})
@@ -64,7 +65,7 @@ def gym_env(game_name: str,
     Returns:
         A fully initialized game env ready for RL-like training
     """
-    game_env = env(game_name, game_instance_filter=game_instance_filter, single_pass=single_pass, callbacks=callbacks, reward_func=reward_func, feedback_func=feedback_func)
+    game_env = env(game_name, instances_filter=instances_filter, single_pass=single_pass, callbacks=callbacks, reward_func=reward_func, feedback_func=feedback_func)
     game_env = SinglePlayerWrapper(game_env, learner_agent, env_agents=env_agents)
     game_env = AECToGymWrapper(game_env)
     return game_env
@@ -72,7 +73,7 @@ def gym_env(game_name: str,
 
 def env(game_name: str,
         *,
-        game_instance_filter: Callable[[str, str], list[int]] | None = None,
+        instances_filter: Callable[[dict], bool] | None = None,
         single_pass: bool = False,
         callbacks: GameBenchmarkCallbackList | None = None,
         reward_func: Callable[[dict, str, GameState, dict], float] | None = None,
@@ -94,7 +95,8 @@ def env(game_name: str,
 
     Args:
         game_name: The name of the clem-game to wrap as a PZ env
-        game_instance_filter: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
+        instances_filter: A condition to filter the list of dicts with "experiment" and "game_instance" keys.
+            If the filter is None, then all game instances will be used.
         single_pass: Whether to run through the game instances only once or multiple times.
         callbacks: a list of callbacks to be applied to the environment lifecycle
         reward_func: a callable (observation, action, state, info) -> float to compute the reward signal.
@@ -116,9 +118,10 @@ def env(game_name: str,
     # Warn env users in case of wrong method execution order
     game_env = OrderEnforcingWrapper(game_env)
 
-    # Load the packaged default instances.json to be played and pass an optional filter
-    game_iterator = GameInstanceIterator.from_game_spec(game_spec, sub_selector=game_instance_filter)
-    game_env = GameInstanceIteratorWrapper(game_env, game_iterator, single_pass=single_pass)
+    # Load the packaged default instances.json to be played and apply an optional filter
+    game_instances = GameInstances.from_game_spec(game_spec)
+    game_instances = game_instances.filter(instances_filter)
+    game_env = GameInstanceIteratorWrapper(game_env, game_instances, single_pass=single_pass)
     return game_env
 
 

--- a/clemcore/clemgame/envs/pettingzoo/wrappers.py
+++ b/clemcore/clemgame/envs/pettingzoo/wrappers.py
@@ -6,7 +6,9 @@ import gymnasium
 from clemcore.backends.model_registry import Model, CustomResponseModel, ModelSpec
 from clemcore.clemgame import GameBenchmarkCallbackList
 from clemcore.clemgame.registry import GameSpec
-from clemcore.clemgame.instances import GameInstanceIterator
+from itertools import cycle
+
+from clemcore.clemgame.instances import GameInstances
 from clemcore.clemgame.benchmark import GameBenchmark
 
 from gymnasium.core import ActType, ObsType
@@ -210,29 +212,28 @@ class GameBenchmarkWrapper(BaseWrapper):
 
 class GameInstanceIteratorWrapper(BaseWrapper):
     """
-    A wrapper that iterates through a GameInstanceIterator, either once or infinitely.
+    A wrapper that iterates through a GameInstances collection, either once or infinitely.
 
     Args:
         wrapped_env: A pettingzoo AECEnv instance.
-        game_iterator: An instance of GameInstanceIterator pre-loaded with instances.
-        single_pass: If True, the iterator stops after passed once through all instances (e.g., for evaluation).
+        game_instances: A GameInstances collection to iterate over.
+        single_pass: If True, the iterator stops after one full pass (e.g., for evaluation).
                      If False (default), the iterator cycles infinitely (e.g., for RL training).
     """
 
-    def __init__(self, wrapped_env: AECEnv, game_iterator: GameInstanceIterator, single_pass: bool = False):
+    def __init__(self, wrapped_env: AECEnv, game_instances: GameInstances, single_pass: bool = False):
         super().__init__(wrapped_env)
-        self.game_iterator = game_iterator.__deepcopy__()
-        self.game_iterator.reset(verbose=True)
+        stdout_logger.info("Iterating over %s", game_instances.describe())
         if not single_pass:
             stdout_logger.info("Detected single_pass=False, cycling through instances infinitely.")
-            from itertools import cycle
-            self.game_iterator = cycle(self.game_iterator)
+            self._iter = cycle(game_instances)
         else:
             stdout_logger.info("Detected single_pass=True, stopping after first pass through all instances.")
+            self._iter = iter(game_instances)
 
     def reset(self, seed: int | None = None, options: dict | None = None):
-        experiment, game_instance = next(self.game_iterator)
+        row = next(self._iter)
         options = options or {}
-        options["experiment"] = experiment
-        options["game_instance"] = game_instance
+        options["experiment"] = row["experiment"]
+        options["game_instance"] = row["game_instance"]
         super().reset(seed=seed, options=options)

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -31,6 +31,138 @@ def to_instance_filter(dataset) -> Callable[[str, str], List[int]]:
     return lambda game, experiment: tasks_by_group[(game, experiment)]
 
 
+def to_rows(instances: dict) -> list[dict]:
+    """Transforms a hierarchical instances dict into a flat list of row dicts.
+
+    Each row has two keys:
+        - "experiment": the experiment metadata (all fields except "game_instances")
+        - "game_instance": the individual instance data (game_id and instance-specific fields)
+
+    The instances dict must follow this structure:
+        {
+            "experiments": [
+                {
+                    "name": <experiment-name>,
+                    "param1": "value1",
+                    "game_instances": [
+                        {"game_id": <value>, ...},
+                        {"game_id": <value>, ...}
+                    ]
+                }
+            ]
+        }
+
+    Raises:
+        ValueError: If the instances dict is missing "experiments", it is not a list, or it is empty.
+    """
+    if "experiments" not in instances:
+        raise ValueError("No 'experiments' key in instances")
+    if not isinstance(instances["experiments"], list):
+        raise ValueError("'experiments' must be a list")
+    if len(instances["experiments"]) == 0:
+        raise ValueError("'experiments' list is empty")
+    results = []
+    experiment_names = []
+    for experiment in instances["experiments"]:
+        experiment_names.append(experiment["name"])
+        for game_instance in experiment["game_instances"]:
+            experiment_data = {k: experiment[k] for k in experiment if k != 'game_instances'}
+            results.append({"experiment": experiment_data, "game_instance": game_instance})
+    return results
+
+
+class GameInstances:
+    """A collection of game instance rows for a single game, loaded from instances.json.
+
+    Each row is a dict with two keys:
+        - "experiment": the experiment metadata (name and parameters, excluding game_instances)
+        - "game_instance": the individual instance data (game_id and instance-specific parameters)
+
+    Rows are produced by `to_rows()` from the hierarchical instances.json structure and held
+    eagerly in memory. Use `filter()` to sub-select rows, and `find_by_game_id()` for direct lookup.
+
+    Args:
+        game_name: The name of the game these instances belong to.
+        rows: Flat list of row dicts as returned by `to_rows()`.
+    """
+
+    def __init__(self, game_name: str, rows: list):
+        assert game_name is not None, "Game name must be given as 'game_name'"
+        assert rows is not None, "Instances must be given as 'rows'"
+        self._game_name = game_name
+        self._rows: list[dict] = rows
+        self._experiment_names = list({row["experiment"]["name"] for row in rows})
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def __len__(self):
+        return len(self._rows)
+
+    def __str__(self):
+        return f"GameInstances({self._game_name}, {len(self._experiment_names)} experiments, {len(self._rows)} rows)"
+
+    def describe(self) -> str:
+        """Returns a detailed description, including experiment names, for logging."""
+        return (f"{self._game_name}: {len(self._rows)} rows "
+                f"from {len(self._experiment_names)} experiments: {self._experiment_names}")
+
+    def filter(self, condition: Callable[[dict], bool]) -> "GameInstances":
+        """Returns a new GameInstances containing only rows for which the condition returns True.
+
+        The condition receives a single row dict with "experiment" and "game_instance" keys,
+        aligned with the HuggingFace Dataset.filter() signature for future compatibility.
+
+        Args:
+            condition: A callable that takes a row dict and returns True to keep the row.
+        """
+        rows = [row for row in self._rows if condition(row)]
+        return GameInstances(self._game_name, rows)
+
+    def find_by_game_id(self, game_id) -> dict:
+        """Returns the row dict for the given game_id or raises ValueError if not found.
+
+        Args:
+            game_id: The game_id to look up (as stored in row["game_instance"]["game_id"]).
+        """
+        for row in self._rows:
+            if row["game_instance"]["game_id"] == game_id:
+                return row
+        raise ValueError(f"game_id={game_id!r} not found in game instances for {self._game_name}")
+
+    @classmethod
+    def from_game_spec(cls, game_spec: GameSpec) -> "GameInstances":
+        """Load game instances from the path and file name defined in the given GameSpec.
+
+        Args:
+            game_spec: The game spec providing game_name, game_path, and optional instances file name.
+        """
+        if not hasattr(game_spec, "instances"):
+            game_spec.instances = "instances"
+        return cls.from_file(
+            game_spec.game_name,
+            os.path.join(game_spec.game_path, "in"),
+            game_spec.instances
+        )
+
+    @classmethod
+    def from_file(cls,
+                  game_name: str,
+                  instance_dir_path: str,
+                  instance_file_name: str = "instances") -> "GameInstances":
+        """Load game instances from a JSON file on disk.
+
+        Args:
+            game_name: The name of the game these instances belong to.
+            instance_dir_path: Path to the directory containing the instances JSON file.
+            instance_file_name: Name of the instances file (without .json extension).
+        """
+        file_path = os.path.join(instance_dir_path, instance_file_name)
+        instances = load_json(file_path)
+        rows = to_rows(instances)
+        return cls(game_name, rows)
+
+
 class GameInstanceIterator:
     """
     The instances.json must follow the structure:

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -3,8 +3,7 @@ import collections
 import logging
 import os
 import random
-from copy import copy
-from typing import Dict, final, Optional, Callable, List, Tuple
+from typing import Dict, final, Callable, List
 
 import numpy as np
 from clemcore.clemgame.registry import GameSpec
@@ -107,7 +106,7 @@ class GameInstances:
         return (f"{self._game_name}: {len(self._rows)} rows "
                 f"from {len(self._experiment_names)} experiments: {self._experiment_names}")
 
-    def filter(self, condition: Callable[[dict], bool]) -> "GameInstances":
+    def filter(self, condition: Callable[[dict], bool] | None) -> "GameInstances":
         """Returns a new GameInstances containing only rows for which the condition returns True.
 
         The condition receives a single row dict with "experiment" and "game_instance" keys,
@@ -116,6 +115,8 @@ class GameInstances:
         Args:
             condition: A callable that takes a row dict and returns True to keep the row.
         """
+        if condition is None:
+            return self
         rows = [row for row in self._rows if condition(row)]
         return GameInstances(self._game_name, rows)
 
@@ -161,140 +162,6 @@ class GameInstances:
         instances = load_json(file_path)
         rows = to_rows(instances)
         return cls(game_name, rows)
-
-
-class GameInstanceIterator:
-    """
-    The instances.json must follow the structure:
-        "experiments": [ # this is required
-            {
-                "name": <experiment-name>, # this is required
-                "param1": "value1", # optional
-                "param2": "value2", # optional
-                "game_instances": [ # this is required
-                    {"game_id": <value>, "initial_prompt": ... },
-                    {"game_id": <value>, "initial_prompt": ... }
-                ]
-            }
-
-    Args:
-        game_name: The name of the game to which the instances belong to.
-        instances: The instances dict with experiments and game instances.
-        sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
-            If a mapping returns None, then all game instances will be used.
-    """
-
-    def __init__(self,
-                 game_name: str,
-                 instances: Dict,
-                 *,
-                 sub_selector: Optional[Callable[[str, str], List[int]]] = None):
-        assert game_name is not None, "Game name must be given"
-        assert instances is not None, "Instances must be given"
-        self._game_name = game_name
-        self._instances: Dict = instances
-        self._sub_selector: Optional[Callable[[str, str], List[int]]] = sub_selector
-        self._queue = []
-
-    def __iter__(self):
-        return self
-
-    def __next__(self) -> Tuple[Dict, Dict]:
-        try:
-            return self._queue.pop(0)
-        except IndexError:
-            raise StopIteration()
-
-    def __len__(self):
-        return len(self._queue)
-
-    def __deepcopy__(self) -> "GameInstanceIterator":
-        _copy = type(self).__new__(self.__class__)
-        _copy._game_name = self._game_name
-        _copy._instances = self._instances
-        _copy._sub_selector = self._sub_selector
-        _copy._queue = copy(self._queue)  # no need to copy the underlying instances
-        return _copy
-
-    def reset(self, verbose: bool = False) -> "GameInstanceIterator":
-        self._queue = []
-        experiment_names = []
-        num_instances = 0
-        for index, experiment in enumerate(self._instances["experiments"]):
-            filtered_experiment = {k: experiment[k] for k in experiment if k != 'game_instances'}
-            selected_ids: Optional[List[int]] = None
-            # some bookkeeping and logging
-            if self._sub_selector is None:
-                experiment_names.append(experiment["name"])
-            else:
-                selected_ids = self._sub_selector(self._game_name, experiment["name"])
-                if selected_ids is None:  # use all instances
-                    experiment_names.append(experiment["name"])
-                elif len(selected_ids) == 0:
-                    if verbose:
-                        stdout_logger.info("Skip experiment %s for %s", experiment["name"], self._game_name)
-                else:
-                    experiment_names.append(experiment["name"])
-                    if verbose:
-                        stdout_logger.info("Sub-select for %s experiment %s instances with game_ids: %s",
-                                           self._game_name, experiment["name"], selected_ids)
-            # add instances to queue, if eligible
-            for game_instance in experiment["game_instances"]:
-                if selected_ids is None or game_instance["game_id"] in selected_ids:
-                    self._queue.append((filtered_experiment, game_instance))
-                    num_instances += 1
-        if verbose:
-            stdout_logger.info("Prepared instance queue for %s using %s experiments %s and %s instances in total.",
-                               self._game_name, len(experiment_names), experiment_names, num_instances)
-        return self
-
-    @classmethod
-    def from_game_spec(cls,
-                       game_spec: GameSpec,
-                       *,
-                       sub_selector: Optional[Callable[[str, str], List[int]]] = None):
-        """Load a game instance iterator using information from the given game spec.
-
-        Args:
-            game_spec: The game spec with a game path and instance file name.
-            sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
-                If a mapping returns None, then all game instances will be used.
-        """
-        if not hasattr(game_spec, "instances"):
-            game_spec.instances = "instances"  # if not already set, fallback to default file name
-        return cls.from_file(
-            game_spec.game_name,
-            os.path.join(game_spec.game_path, "in"),
-            game_spec.instances,
-            sub_selector=sub_selector
-        )
-
-    @classmethod
-    def from_file(cls,
-                  game_name: str,
-                  instance_dir_path: str,
-                  instance_file_name: str = "instances",
-                  *,
-                  sub_selector: Optional[Callable[[str, str], List[int]]] = None):
-        """Load a game instance iterator using the given file path.
-
-        Args:
-            game_name: The name of the game to which the instances belong to. Necessary for the sub_selector to work.
-            instance_dir_path: The path the directory containing a JSON file with the game instances.
-            instance_file_name: The name of the instance file to load.
-            sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
-                If a mapping returns None, then all game instances will be used.
-        """
-        file_path = os.path.join(instance_dir_path, instance_file_name)
-        instances = load_json(file_path)
-        if "experiments" not in instances:
-            raise ValueError(f"{game_name}: No 'experiments' key in {instance_file_name}")
-        experiments = instances["experiments"]
-        if not isinstance(experiments, list):
-            raise ValueError(f"{game_name}: Experiments in {instance_file_name} is not a list")
-        if len(experiments) == 0:
-            raise ValueError(f"{game_name}: Experiments list in {instance_file_name} is empty")
-        return cls(game_name, instances, sub_selector=sub_selector)
 
 
 class GameInstanceGenerator(GameResourceLocator):

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -13,21 +13,28 @@ from clemcore.clemgame.resources import GameResourceLocator, load_json
 stdout_logger = logging.getLogger("clemcore.run")
 
 
-def to_instance_filter(dataset) -> Callable[[str, str], List[int]]:
+def to_instance_filter(dataset) -> Callable[[dict], bool]:
     """
-    Converts the given dataset into a game instance filter function.
+    Converts the given dataset into a filter condition for use with GameInstances.filter().
 
     Args:
-        dataset: a list of dict-like rows with game, experiment, task_id values
+        dataset: a list of dict-like rows with game, experiment, and task_id fields
 
     Returns:
-        A callable mapping of (game_name, experiment_name) tuples to lists of task ids (game instance ids)
+        A callable that takes a row dict and returns True if the row's (game_name, experiment, game_id)
+        triple is present in the dataset.
     """
-    tasks_by_group = collections.defaultdict(list)
+    whitelist = set()
     for row in dataset:
-        key = (row['game'], row['experiment'])
-        tasks_by_group[key].append(int(row['task_id']))
-    return lambda game, experiment: tasks_by_group[(game, experiment)]
+        whitelist.add((row['game'], row['experiment'], int(row['task_id'])))
+
+    def filter_fn(row: dict) -> bool:
+        game_name = row["game_name"]
+        game_id = row["game_instance"]["game_id"]
+        experiment_name = row["experiment"]["name"]
+        return (game_name, experiment_name, game_id) in whitelist
+
+    return filter_fn
 
 
 def to_rows(instances: dict) -> list[dict]:

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -37,10 +37,11 @@ def to_instance_filter(dataset) -> Callable[[dict], bool]:
     return filter_fn
 
 
-def to_rows(instances: dict) -> list[dict]:
+def to_rows(game_name: str, instances: dict) -> list[dict]:
     """Transforms a hierarchical instances dict into a flat list of row dicts.
 
-    Each row has two keys:
+    Each row has three keys:
+        - "game_name": the name of the game these instances belong to
         - "experiment": the experiment metadata (all fields except "game_instances")
         - "game_instance": the individual instance data (game_id and instance-specific fields)
 
@@ -58,6 +59,10 @@ def to_rows(instances: dict) -> list[dict]:
             ]
         }
 
+    Args:
+        game_name: The name of the game, included in each row to enable cross-game filtering.
+        instances: The hierarchical instances dict loaded from instances.json.
+
     Raises:
         ValueError: If the instances dict is missing "experiments", it is not a list, or it is empty.
     """
@@ -68,19 +73,18 @@ def to_rows(instances: dict) -> list[dict]:
     if len(instances["experiments"]) == 0:
         raise ValueError("'experiments' list is empty")
     results = []
-    experiment_names = []
     for experiment in instances["experiments"]:
-        experiment_names.append(experiment["name"])
         for game_instance in experiment["game_instances"]:
             experiment_data = {k: experiment[k] for k in experiment if k != 'game_instances'}
-            results.append({"experiment": experiment_data, "game_instance": game_instance})
+            results.append({"game_name": game_name, "experiment": experiment_data, "game_instance": game_instance})
     return results
 
 
 class GameInstances:
     """A collection of game instance rows for a single game, loaded from instances.json.
 
-    Each row is a dict with two keys:
+    Each row is a dict with three keys:
+        - "game_name": the name of the game these instances belong to
         - "experiment": the experiment metadata (name and parameters, excluding game_instances)
         - "game_instance": the individual instance data (game_id and instance-specific parameters)
 
@@ -167,7 +171,7 @@ class GameInstances:
         """
         file_path = os.path.join(instance_dir_path, instance_file_name)
         instances = load_json(file_path)
-        rows = to_rows(instances)
+        rows = to_rows(game_name, instances)
         return cls(game_name, rows)
 
 

--- a/clemcore/clemgame/runners/batchwise.py
+++ b/clemcore/clemgame/runners/batchwise.py
@@ -197,7 +197,7 @@ def run(game_benchmark: GameBenchmark,
 
     Args:
         game_benchmark: The GameBenchmark to run.
-        game_instance_iterator: An iterator over the game instances to be played.
+        game_instances: The collection of game instances to be played.
         player_models: List of player models participating in the benchmark.
         callbacks: Callback list to notify about benchmark and game events.
         batch_size: The batch size to use for all player models.
@@ -234,7 +234,7 @@ def __prepare_game_sessions(game_benchmark: GameBenchmark,
 
     Args:
         game_benchmark: The GameBenchmark providing game instances.
-        game_instance_iterator: Iterator over game instances.
+        game_instances: The collection of game instances to iterate over.
         player_models: List of player models to pass to the GameMasterEnv.
         callbacks: Callback list to notify on game start.
         verbose: Whether to show progress bar.

--- a/clemcore/clemgame/runners/batchwise.py
+++ b/clemcore/clemgame/runners/batchwise.py
@@ -9,7 +9,7 @@ from clemcore.clemgame import (
     GameBenchmark,
     GameBenchmarkCallbackList,
     Player,
-    GameInstanceIterator
+    GameInstances
 )
 from clemcore.clemgame.envs.pettingzoo import GameMasterEnv
 
@@ -179,7 +179,7 @@ class DynamicBatchDataLoader(Iterable):
 
 
 def run(game_benchmark: GameBenchmark,
-        game_instance_iterator: GameInstanceIterator,
+        game_instances: GameInstances,
         player_models: List[BatchGenerativeModel],
         *,
         callbacks: GameBenchmarkCallbackList,
@@ -210,7 +210,7 @@ def run(game_benchmark: GameBenchmark,
         "Not all player models support batching. Use the sequential runner instead."
 
     callbacks.on_benchmark_start(game_benchmark)
-    game_sessions = __prepare_game_sessions(game_benchmark, game_instance_iterator, player_models, callbacks,
+    game_sessions = __prepare_game_sessions(game_benchmark, game_instances, player_models, callbacks,
                                             verbose=True)
     num_sessions = len(game_sessions)
     if batch_size > num_sessions:
@@ -220,7 +220,7 @@ def run(game_benchmark: GameBenchmark,
 
 
 def __prepare_game_sessions(game_benchmark: GameBenchmark,
-                            game_instance_iterator: GameInstanceIterator,
+                            game_instances: GameInstances,
                             player_models: List[BatchGenerativeModel],
                             callbacks: Optional[GameBenchmarkCallbackList] = None,
                             verbose: bool = False):
@@ -249,13 +249,14 @@ def __prepare_game_sessions(game_benchmark: GameBenchmark,
     error_count = 0
     game_sessions: List[GameSession] = []
     if verbose:
-        pbar = tqdm(total=len(game_instance_iterator), desc="Setup game instances", dynamic_ncols=True)
-    for session_id, (experiment, game_instance) in enumerate(game_instance_iterator):
+        pbar = tqdm(total=len(game_instances), desc="Setup game instances", dynamic_ncols=True)
+    for session_id, row in enumerate(game_instances):
         try:
+            game_instance = row["game_instance"]
             game_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
             game_env.reset(options={
                 "player_models": player_models,
-                "experiment": experiment,
+                "experiment": row["experiment"],
                 "game_instance": game_instance
             })
             game_sessions.append(GameSession(session_id, game_env, game_instance))

--- a/clemcore/clemgame/runners/dispatch.py
+++ b/clemcore/clemgame/runners/dispatch.py
@@ -2,13 +2,13 @@ import logging
 from typing import List
 
 from clemcore.backends import Model, BatchGenerativeModel
-from clemcore.clemgame import GameBenchmark, GameBenchmarkCallbackList, GameInstanceIterator
+from clemcore.clemgame import GameBenchmark, GameBenchmarkCallbackList, GameInstances
 
 stdout_logger = logging.getLogger("clemcore.run")
 
 
 def run(game_benchmark: GameBenchmark,
-        game_instance_iterator: GameInstanceIterator,
+        game_instances: GameInstances,
         player_models: List[Model | BatchGenerativeModel],
         *,
         callbacks: GameBenchmarkCallbackList = None,
@@ -37,7 +37,7 @@ def run(game_benchmark: GameBenchmark,
                            game_benchmark.game_name,
                            ",".join(player_model.name for player_model in player_models),
                            batch_size)
-        batchwise.run(game_benchmark, game_instance_iterator, player_models, callbacks=callbacks, batch_size=batch_size)
+        batchwise.run(game_benchmark, game_instances, player_models, callbacks=callbacks, batch_size=batch_size)
     else:
         from clemcore.clemgame.runners import sequential  # lazy import
         if not Model.all_support_batching(player_models):
@@ -48,4 +48,4 @@ def run(game_benchmark: GameBenchmark,
                            game_benchmark.game_name,
                            ",".join(player_model.name for player_model in player_models),
                            batch_size)
-        sequential.run(game_benchmark, game_instance_iterator, player_models, callbacks=callbacks)
+        sequential.run(game_benchmark, game_instances, player_models, callbacks=callbacks)

--- a/clemcore/clemgame/runners/dispatch.py
+++ b/clemcore/clemgame/runners/dispatch.py
@@ -25,7 +25,7 @@ def run(game_benchmark: GameBenchmark,
         Note: Slurk backends do not support batching, hence will run always sequentially (for now).
     Args:
         game_benchmark: The game benchmark to run, that is, a factory to create the proper game master.
-        game_instance_iterator: An iterator over the game instances to be played.
+        game_instances: The collection of game instances to be played.
         player_models: A list of backends.Model instances to run the game with.
         callbacks: Callbacks to be invoked during the benchmark run.
         batch_size: The batch size to use (default: 1).

--- a/clemcore/clemgame/runners/sequential.py
+++ b/clemcore/clemgame/runners/sequential.py
@@ -4,7 +4,7 @@ from typing import List
 from tqdm import tqdm
 
 from clemcore.backends import Model
-from clemcore.clemgame import GameBenchmarkCallbackList, GameInstanceIterator, GameStep, GameBenchmark
+from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenchmark
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
 
 module_logger = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ stdout_logger = logging.getLogger("clemcore.run")
 
 
 def run(game_benchmark: GameBenchmark,
-        game_instance_iterator: GameInstanceIterator,
+        game_instances: GameInstances,
         player_models: List[Model],
         *,
         callbacks: GameBenchmarkCallbackList
@@ -20,12 +20,12 @@ def run(game_benchmark: GameBenchmark,
     callbacks.on_benchmark_start(game_benchmark)
     game_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
     error_count = 0
-    for experiment, game_instance in tqdm(game_instance_iterator, desc="Playing game instances"):
+    for row in tqdm(game_instances, desc="Playing game instances"):
         try:
             game_env.reset(options={
                 "player_models": player_models,
-                "experiment": experiment,
-                "game_instance": game_instance
+                "experiment": row["experiment"],
+                "game_instance": row["game_instance"]
             })
             for model in player_models:
                 model.reset()  # this is mainly to notify slurk backends; other models are state-less anyway
@@ -40,7 +40,7 @@ def run(game_benchmark: GameBenchmark,
                     response = player(context)
                 game_env.step(response)
         except Exception:  # continue with other instances if something goes wrong
-            message = f"{game_benchmark.game_name}: Exception for instance {game_instance['game_id']} (but continue)"
+            message = f"{game_benchmark.game_name}: Exception for instance {row['game_instance']['game_id']} (but continue)"
             module_logger.exception(message)
             error_count += 1
             for model in player_models:

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -4,14 +4,13 @@ import textwrap
 import logging
 import uvicorn
 from datetime import datetime
-from functools import partial
 from pathlib import Path
 from typing import List, Dict, Union, Callable, Optional, Any
 
 import clemcore.backends as backends
 from clemcore.backends import ModelRegistry, BackendRegistry, Model, KeyRegistry
 from clemcore.clemgame import GameRegistry, GameSpec, InstanceFileSaver, ExperimentFileSaver, \
-    InteractionsFileSaver, GameBenchmarkCallbackList, RunFileSaver, GameInstanceIterator, ResultsFolder, \
+    InteractionsFileSaver, GameBenchmarkCallbackList, RunFileSaver, GameInstances, ResultsFolder, \
     GameBenchmark
 from clemcore import clemeval, get_version
 from clemcore.clemgame.callbacks.files import PlayerFileSaver
@@ -133,14 +132,6 @@ def list_games(game_selector: str, verbose: bool = False):
             print(game_name, wrapper.fill(game_spec["description"]))
 
 
-def experiment_filter(game: str, experiment: str, *, selected_experiment: str, game_ids: Optional[List[int]]):
-    if experiment != selected_experiment:
-        return []  # skip experiment
-    if game_ids is None:
-        return None  # allow all
-    return game_ids
-
-
 def run(game_selector: Union[str, Dict, GameSpec],
         model_selectors: List[backends.ModelSpec],
         *,
@@ -148,7 +139,7 @@ def run(game_selector: Union[str, Dict, GameSpec],
         experiment_name: str = None,
         instances_filename: str = None,
         results_dir_path: Path = None,
-        sub_selector: Callable[[str, str], List[int]] = None,
+        instances_filter: Callable[[dict], bool] | None = None,
         batch_size: int = 1
         ):
     """Run specific model/models with a specified clemgame.
@@ -157,11 +148,11 @@ def run(game_selector: Union[str, Dict, GameSpec],
         model_selectors: One or two selectors for the models that are supposed to play the games.
         gen_args: Text generation parameters for the backend; output length and temperature are implemented for the
             majority of model backends.
-        experiment_name: Name of the experiment to run. Corresponds to the experiment key in the instances JSON file.
+        experiment_name: Name of the experiment to run. Acts as an instance filter.
         instances_filename: Name of the instances JSON file to use for this benchmark run.
         results_dir_path: Path to the results directory in which to store the episode records.
-        sub_selector: A callable mapping from (game_name, experiment_name) tuples to lists of game instance ids.
-            If a mapping returns None, then all game instances will be used.
+        instances_filter: A condition to filter the list of dicts with "experiment" and "game_instance" keys.
+            If the filter is None, then all game instances will be used.
         batch_size: A batch size to use for the run.
     """
     # check games
@@ -191,22 +182,22 @@ def run(game_selector: Union[str, Dict, GameSpec],
             if instances_filename:
                 game_spec.instances = instances_filename  # force the use of cli argument, when given
 
-            if experiment_name:  # establish experiment filter, if given
+            experiment_filter = None
+            if experiment_name:
                 logger.info("Only running experiment: %s", experiment_name)
-                if sub_selector is None:
-                    sub_selector = partial(experiment_filter, selected_experiment=experiment_name, game_ids=None)
-                else:
-                    game_ids = sub_selector(game_spec.game_name, experiment_name)
-                    sub_selector = partial(experiment_filter, selected_experiment=experiment_name, game_ids=game_ids)
+                experiment_filter = lambda row: row["experiment"]["name"] == experiment_name
 
             with GameBenchmark.load_from_spec(game_spec) as game_benchmark:
                 time_start = datetime.now()
                 logger.info(f'Running {game_spec["game_name"]} (models={player_models})')
-                game_instance_iterator = GameInstanceIterator.from_game_spec(game_spec, sub_selector=sub_selector)
-                game_instance_iterator.reset(verbose=True)
+                game_instances = GameInstances.from_game_spec(game_spec)
+                logger.info("Loaded %s (initially)", game_instances.describe())
+                game_instances = game_instances.filter(experiment_filter)
+                game_instances = game_instances.filter(instances_filter)
+                logger.info("Proceed with %s (after applying filters)", game_instances.describe())
                 dispatch.run(
                     game_benchmark,
-                    game_instance_iterator,
+                    game_instances,
                     player_models,
                     callbacks=callbacks,
                     batch_size=batch_size

--- a/tests/test_game_instance_iterator.py
+++ b/tests/test_game_instance_iterator.py
@@ -63,13 +63,13 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_creation(self):
         """Test creating GameInstances."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
         self.assertEqual(len(instances), 3)  # 2 + 1 instances
 
     def test_iteration(self):
         """Test iterating over instances yields row dicts."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
 
         collected = list(instances)
@@ -82,7 +82,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_experiment_excludes_game_instances(self):
         """Test that experiment dict excludes game_instances."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
 
         row = next(iter(instances))
@@ -92,7 +92,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_filter(self):
         """Test filter returns a new GameInstances with matching rows."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
 
         filtered = instances.filter(
@@ -103,7 +103,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_filter_experiment(self):
         """Test filtering to a single experiment."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
 
         filtered = instances.filter(lambda row: row["experiment"]["name"] == "experiment_2")
@@ -112,7 +112,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_find_by_game_id(self):
         """Test finding a row by game_id."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
 
         row = instances.find_by_game_id(2)
@@ -121,7 +121,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_find_by_game_id_not_found(self):
         """Test that find_by_game_id raises ValueError for missing id."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
 
         with self.assertRaises(ValueError):
@@ -179,7 +179,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_requires_game_name(self):
         """Test that game_name is required."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         with self.assertRaises(AssertionError):
             GameInstances(None, rows)
 
@@ -190,7 +190,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_str(self):
         """Test string representation."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
         s = str(instances)
         self.assertIn("test_game", s)
@@ -199,7 +199,7 @@ class GameInstancesTestCase(unittest.TestCase):
 
     def test_describe(self):
         """Test describe includes experiment names."""
-        rows = to_rows(self.get_sample_instances())
+        rows = to_rows("test_game", self.get_sample_instances())
         instances = GameInstances("test_game", rows)
         desc = instances.describe()
         self.assertIn("experiment_1", desc)

--- a/tests/test_game_instance_iterator.py
+++ b/tests/test_game_instance_iterator.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 
-from clemcore.clemgame.instances import GameInstanceIterator, to_instance_filter
+from clemcore.clemgame.instances import GameInstances, to_instance_filter, to_rows
 
 
 class ToInstanceFilterTestCase(unittest.TestCase):
@@ -37,7 +37,7 @@ class ToInstanceFilterTestCase(unittest.TestCase):
         self.assertEqual(result, [])
 
 
-class GameInstanceIteratorTestCase(unittest.TestCase):
+class GameInstancesTestCase(unittest.TestCase):
 
     def get_sample_instances(self):
         """Get sample instances for testing."""
@@ -61,133 +61,91 @@ class GameInstanceIteratorTestCase(unittest.TestCase):
             ]
         }
 
-    def test_iterator_creation(self):
-        """Test creating GameInstanceIterator."""
-        instances = self.get_sample_instances()
-        iterator = GameInstanceIterator("test_game", instances)
-        self.assertEqual(len(iterator), 0)  # Not reset yet
+    def test_creation(self):
+        """Test creating GameInstances."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
+        self.assertEqual(len(instances), 3)  # 2 + 1 instances
 
-    def test_iterator_reset(self):
-        """Test resetting iterator populates queue."""
-        instances = self.get_sample_instances()
-        iterator = GameInstanceIterator("test_game", instances)
-        iterator.reset()
-        self.assertEqual(len(iterator), 3)  # 2 + 1 instances
+    def test_iteration(self):
+        """Test iterating over instances yields row dicts."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
 
-    def test_iterator_iteration(self):
-        """Test iterating over instances."""
-        instances = self.get_sample_instances()
-        iterator = GameInstanceIterator("test_game", instances)
-        iterator.reset()
-
-        collected = list(iterator)
+        collected = list(instances)
         self.assertEqual(len(collected), 3)
 
-        # Check structure: each item is (experiment, instance) tuple
-        exp, inst = collected[0]
-        self.assertEqual(exp["name"], "experiment_1")
-        self.assertEqual(inst["game_id"], 1)
+        # Check structure: each item is a row dict
+        row = collected[0]
+        self.assertEqual(row["experiment"]["name"], "experiment_1")
+        self.assertEqual(row["game_instance"]["game_id"], 1)
 
-    def test_iterator_experiment_filtered(self):
+    def test_experiment_excludes_game_instances(self):
         """Test that experiment dict excludes game_instances."""
-        instances = self.get_sample_instances()
-        iterator = GameInstanceIterator("test_game", instances)
-        iterator.reset()
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
 
-        exp, inst = next(iterator)
-        self.assertNotIn("game_instances", exp)
-        self.assertIn("name", exp)
-        self.assertIn("param", exp)
+        row = next(iter(instances))
+        self.assertNotIn("game_instances", row["experiment"])
+        self.assertIn("name", row["experiment"])
+        self.assertIn("param", row["experiment"])
 
-    def test_iterator_with_sub_selector(self):
-        """Test iterator with sub_selector filter."""
-        instances = self.get_sample_instances()
+    def test_filter(self):
+        """Test filter returns a new GameInstances with matching rows."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
 
-        # Only select game_id 1 from experiment_1
-        def sub_selector(game_name, experiment_name):
-            if experiment_name == "experiment_1":
-                return [1]
-            return None  # Include all for other experiments
+        filtered = instances.filter(
+            lambda row: row["experiment"]["name"] == "experiment_1" and row["game_instance"]["game_id"] == 1
+        )
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(next(iter(filtered))["game_instance"]["game_id"], 1)
 
-        iterator = GameInstanceIterator("test_game", instances, sub_selector=sub_selector)
-        iterator.reset()
+    def test_filter_experiment(self):
+        """Test filtering to a single experiment."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
 
-        collected = list(iterator)
-        # Should have 1 from experiment_1, 1 from experiment_2
-        self.assertEqual(len(collected), 2)
+        filtered = instances.filter(lambda row: row["experiment"]["name"] == "experiment_2")
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(next(iter(filtered))["experiment"]["name"], "experiment_2")
 
-        game_ids = [inst["game_id"] for _, inst in collected]
-        self.assertIn(1, game_ids)
-        self.assertIn(3, game_ids)
-        self.assertNotIn(2, game_ids)
+    def test_find_by_game_id(self):
+        """Test finding a row by game_id."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
 
-    def test_iterator_sub_selector_empty_list(self):
-        """Test that empty list from sub_selector skips experiment."""
-        instances = self.get_sample_instances()
+        row = instances.find_by_game_id(2)
+        self.assertEqual(row["game_instance"]["game_id"], 2)
+        self.assertEqual(row["experiment"]["name"], "experiment_1")
 
-        def sub_selector(game_name, experiment_name):
-            if experiment_name == "experiment_1":
-                return []  # Skip this experiment
-            return None
+    def test_find_by_game_id_not_found(self):
+        """Test that find_by_game_id raises ValueError for missing id."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
 
-        iterator = GameInstanceIterator("test_game", instances, sub_selector=sub_selector)
-        iterator.reset()
-
-        collected = list(iterator)
-        self.assertEqual(len(collected), 1)  # Only experiment_2
-        exp, inst = collected[0]
-        self.assertEqual(exp["name"], "experiment_2")
-
-    def test_iterator_deepcopy(self):
-        """Test deep copying iterator."""
-        instances = self.get_sample_instances()
-        iterator = GameInstanceIterator("test_game", instances)
-        iterator.reset()
-
-        # Consume one item
-        next(iterator)
-        self.assertEqual(len(iterator), 2)
-
-        # Deep copy (note: __deepcopy__ doesn't take memo arg in this implementation)
-        iterator_copy = iterator.__deepcopy__()
-        self.assertEqual(len(iterator_copy), 2)
-
-        # Consume from copy shouldn't affect original
-        next(iterator_copy)
-        self.assertEqual(len(iterator_copy), 1)
-        self.assertEqual(len(iterator), 2)
-
-    def test_iterator_stop_iteration(self):
-        """Test that StopIteration is raised when exhausted."""
-        instances = {"experiments": [{"name": "exp", "game_instances": [{"game_id": 1}]}]}
-        iterator = GameInstanceIterator("test_game", instances)
-        iterator.reset()
-
-        next(iterator)  # Consume the only item
-        with self.assertRaises(StopIteration):
-            next(iterator)
+        with self.assertRaises(ValueError):
+            instances.find_by_game_id(999)
 
     def test_from_file(self):
-        """Test loading iterator from file."""
+        """Test loading instances from file."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            instances = self.get_sample_instances()
+            instances_data = self.get_sample_instances()
             with open(os.path.join(tmpdir, "instances.json"), "w") as f:
-                json.dump(instances, f)
+                json.dump(instances_data, f)
 
-            iterator = GameInstanceIterator.from_file("test_game", tmpdir)
-            iterator.reset()
-            self.assertEqual(len(iterator), 3)
+            instances = GameInstances.from_file("test_game", tmpdir)
+            self.assertEqual(len(instances), 3)
 
     def test_from_file_custom_name(self):
-        """Test loading iterator from file with custom name."""
+        """Test loading instances from file with custom name."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            instances = self.get_sample_instances()
+            instances_data = self.get_sample_instances()
             with open(os.path.join(tmpdir, "custom_instances.json"), "w") as f:
-                json.dump(instances, f)
+                json.dump(instances_data, f)
 
-            iterator = GameInstanceIterator.from_file("test_game", tmpdir, "custom_instances")
-            iterator.reset()
-            self.assertEqual(len(iterator), 3)
+            instances = GameInstances.from_file("test_game", tmpdir, "custom_instances")
+            self.assertEqual(len(instances), 3)
 
     def test_from_file_missing_experiments_raises(self):
         """Test that missing experiments key raises ValueError."""
@@ -196,7 +154,7 @@ class GameInstanceIteratorTestCase(unittest.TestCase):
                 json.dump({"not_experiments": []}, f)
 
             with self.assertRaises(ValueError) as context:
-                GameInstanceIterator.from_file("test_game", tmpdir)
+                GameInstances.from_file("test_game", tmpdir)
             self.assertIn("experiments", str(context.exception).lower())
 
     def test_from_file_experiments_not_list_raises(self):
@@ -206,8 +164,8 @@ class GameInstanceIteratorTestCase(unittest.TestCase):
                 json.dump({"experiments": "not_a_list"}, f)
 
             with self.assertRaises(ValueError) as context:
-                GameInstanceIterator.from_file("test_game", tmpdir)
-            self.assertIn("not a list", str(context.exception).lower())
+                GameInstances.from_file("test_game", tmpdir)
+            self.assertIn("list", str(context.exception).lower())
 
     def test_from_file_empty_experiments_raises(self):
         """Test that empty experiments list raises ValueError."""
@@ -216,19 +174,36 @@ class GameInstanceIteratorTestCase(unittest.TestCase):
                 json.dump({"experiments": []}, f)
 
             with self.assertRaises(ValueError) as context:
-                GameInstanceIterator.from_file("test_game", tmpdir)
+                GameInstances.from_file("test_game", tmpdir)
             self.assertIn("empty", str(context.exception).lower())
 
-    def test_iterator_requires_game_name(self):
+    def test_requires_game_name(self):
         """Test that game_name is required."""
-        instances = self.get_sample_instances()
+        rows = to_rows(self.get_sample_instances())
         with self.assertRaises(AssertionError):
-            GameInstanceIterator(None, instances)
+            GameInstances(None, rows)
 
-    def test_iterator_requires_instances(self):
-        """Test that instances is required."""
+    def test_requires_rows(self):
+        """Test that rows is required."""
         with self.assertRaises(AssertionError):
-            GameInstanceIterator("game", None)
+            GameInstances("game", None)
+
+    def test_str(self):
+        """Test string representation."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
+        s = str(instances)
+        self.assertIn("test_game", s)
+        self.assertIn("2", s)  # 2 experiments
+        self.assertIn("3", s)  # 3 rows
+
+    def test_describe(self):
+        """Test describe includes experiment names."""
+        rows = to_rows(self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
+        desc = instances.describe()
+        self.assertIn("experiment_1", desc)
+        self.assertIn("experiment_2", desc)
 
 
 if __name__ == '__main__':

--- a/tests/test_game_instance_iterator.py
+++ b/tests/test_game_instance_iterator.py
@@ -6,10 +6,14 @@ import unittest
 from clemcore.clemgame.instances import GameInstances, to_instance_filter, to_rows
 
 
+def make_row(game_name, experiment_name, game_id):
+    return {"game_name": game_name, "experiment": {"name": experiment_name}, "game_instance": {"game_id": game_id}}
+
+
 class ToInstanceFilterTestCase(unittest.TestCase):
 
     def test_filter_from_dataset(self):
-        """Test creating filter from dataset."""
+        """Test creating filter condition from dataset."""
         dataset = [
             {"game": "game_a", "experiment": "exp1", "task_id": "1"},
             {"game": "game_a", "experiment": "exp1", "task_id": "2"},
@@ -18,23 +22,19 @@ class ToInstanceFilterTestCase(unittest.TestCase):
         ]
         filter_fn = to_instance_filter(dataset)
 
-        # Test filtering
-        result = filter_fn("game_a", "exp1")
-        self.assertEqual(result, [1, 2])
+        self.assertTrue(filter_fn(make_row("game_a", "exp1", 1)))
+        self.assertTrue(filter_fn(make_row("game_a", "exp1", 2)))
+        self.assertFalse(filter_fn(make_row("game_a", "exp1", 3)))
+        self.assertTrue(filter_fn(make_row("game_a", "exp2", 3)))
+        self.assertTrue(filter_fn(make_row("game_b", "exp1", 1)))
 
-        result = filter_fn("game_a", "exp2")
-        self.assertEqual(result, [3])
-
-        result = filter_fn("game_b", "exp1")
-        self.assertEqual(result, [1])
-
-    def test_filter_returns_empty_for_missing(self):
-        """Test that filter returns empty list for missing game/experiment."""
+    def test_filter_returns_false_for_missing(self):
+        """Test that filter returns False for missing game/experiment/task_id."""
         dataset = [{"game": "game_a", "experiment": "exp1", "task_id": "1"}]
         filter_fn = to_instance_filter(dataset)
 
-        result = filter_fn("nonexistent", "exp")
-        self.assertEqual(result, [])
+        self.assertFalse(filter_fn(make_row("nonexistent", "exp1", 1)))
+        self.assertFalse(filter_fn(make_row("game_a", "exp1", 99)))
 
 
 class GameInstancesTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

Replaces the lazy, queue-based `GameInstanceIterator` with `GameInstances`, an eager collection of self-contained row dicts. This is a prerequisite for supporting random-access reset strategies (e.g. for RL training where the agent selects the next task), and aligns the internal data model with a potential future migration to HuggingFace Datasets (see #274).

- `GameInstances` holds a flat list of row dicts, each with three keys: `game_name`, `experiment`, `game_instance`
- `to_rows(game_name, instances)` produces the flat row structure; including `game_name` in every row enables cross-game filtering with a single filter condition
- `GameInstances.filter(condition)` mirrors the HuggingFace `Dataset.filter()` signature for future compatibility
- `to_instance_filter(dataset)` updated to return `Callable[[dict], bool]`, compatible with `GameInstances.filter()`
- `GameInstanceIteratorWrapper` (pettingzoo) updated to accept `GameInstances` directly, using `iter()` or `cycle()`
- `gym_env()`/`env()` parameter renamed `game_instance_filter` → `instances_filter` for consistency
- `cli.run()` parameter `sub_selector` replaced with `instances_filter: Callable[[dict], bool] | None`
- All runners (`sequential`, `batchwise`, `dispatch`) updated to iterate over row dicts

## Test plan

- [ ] All existing tests pass (`244 passed`)
- [ ] `test_game_instance_iterator.py` fully rewritten to test `GameInstances` and the updated `to_instance_filter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)