### PR TITLE
Support game_id random access in GameInstanceIteratorWrapper

### DIFF
--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -71,7 +71,10 @@ class ClemGameEnvironment(Environment):
         self._game_env.close()
 
     def reset(self, seed=None, episode_id=None, **kwargs) -> ClemGameObservation:
-        observation, info = self._game_env.reset()
+        if episode_id is not None:
+            kwargs["episode_id"] = episode_id
+        options = kwargs if kwargs else None
+        observation, info = self._game_env.reset(seed=seed, options=options)
         self._state.step_count = 0
         self._state.episode_count += 1
         self._state.episode_id = f"episode_{self._state.episode_count}"

--- a/clemcore/clemgame/envs/pettingzoo/wrappers.py
+++ b/clemcore/clemgame/envs/pettingzoo/wrappers.py
@@ -224,6 +224,7 @@ class GameInstanceIteratorWrapper(BaseWrapper):
     def __init__(self, wrapped_env: AECEnv, game_instances: GameInstances, single_pass: bool = False):
         super().__init__(wrapped_env)
         stdout_logger.info("Iterating over %s", game_instances.describe())
+        self._game_instances = game_instances
         if not single_pass:
             stdout_logger.info("Detected single_pass=False, cycling through instances infinitely.")
             self._iter = cycle(game_instances)
@@ -232,8 +233,12 @@ class GameInstanceIteratorWrapper(BaseWrapper):
             self._iter = iter(game_instances)
 
     def reset(self, seed: int | None = None, options: dict | None = None):
-        row = next(self._iter)
         options = options or {}
+        game_id = options.pop("game_id", None)  # consumed here; not forwarded to the underlying game env
+        if game_id is not None:
+            row = self._game_instances.find_by_game_id(game_id)
+        else:
+            row = next(self._iter)
         options["experiment"] = row["experiment"]
         options["game_instance"] = row["game_instance"]
         super().reset(seed=seed, options=options)

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -131,12 +131,13 @@ class GameInstances:
         rows = [row for row in self._rows if condition(row)]
         return GameInstances(self._game_name, rows)
 
-    def find_by_game_id(self, game_id) -> dict:
+    def find_by_game_id(self, game_id: int | str) -> dict:
         """Returns the row dict for the given game_id or raises ValueError if not found.
 
         Args:
-            game_id: The game_id to look up (as stored in row["game_instance"]["game_id"]).
+            game_id: The game_id to look up. Coerced to int to handle string values from HTTP callers.
         """
+        game_id = int(game_id)
         for row in self._rows:
             if row["game_instance"]["game_id"] == game_id:
                 return row

--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -139,7 +139,7 @@ class GameInstances:
         """
         game_id = int(game_id)
         for row in self._rows:
-            if row["game_instance"]["game_id"] == game_id:
+            if int(row["game_instance"]["game_id"]) == game_id:
                 return row
         raise ValueError(f"game_id={game_id!r} not found in game instances for {self._game_name}")
 

--- a/tests/test_game_instance_iterator.py
+++ b/tests/test_game_instance_iterator.py
@@ -119,6 +119,14 @@ class GameInstancesTestCase(unittest.TestCase):
         self.assertEqual(row["game_instance"]["game_id"], 2)
         self.assertEqual(row["experiment"]["name"], "experiment_1")
 
+    def test_find_by_game_id_accepts_string(self):
+        """Test that find_by_game_id coerces string game_id to int (e.g. from HTTP callers)."""
+        rows = to_rows("test_game", self.get_sample_instances())
+        instances = GameInstances("test_game", rows)
+
+        row = instances.find_by_game_id("2")
+        self.assertEqual(row["game_instance"]["game_id"], 2)
+
     def test_find_by_game_id_not_found(self):
         """Test that find_by_game_id raises ValueError for missing id."""
         rows = to_rows("test_game", self.get_sample_instances())

--- a/tests/test_pettingzoo_wrappers.py
+++ b/tests/test_pettingzoo_wrappers.py
@@ -5,9 +5,11 @@ from clemcore.backends.model_registry import CustomResponseModel, ModelSpec
 from clemcore.clemgame.envs.pettingzoo.wrappers import (
     AgentControlWrapper,
     SinglePlayerWrapper,
+    GameInstanceIteratorWrapper,
     order_agent_mapping_by_agent_id,
 )
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
+from clemcore.clemgame.instances import GameInstances, to_rows
 
 
 class OrderAgentMappingTestCase(unittest.TestCase):
@@ -128,6 +130,73 @@ class GameMasterEnvObserveTestCase(unittest.TestCase):
         result = env.observe("player_0")
         self.assertEqual(result, context)
         mock_gm.get_context_for.assert_called_once_with(mock_player)
+
+
+class GameInstanceIteratorWrapperTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_env = MagicMock()
+        instances_data = {
+            "experiments": [{
+                "name": "exp1",
+                "game_instances": [
+                    {"game_id": 1},
+                    {"game_id": 2},
+                    {"game_id": 3},
+                ]
+            }]
+        }
+        self.instances = GameInstances("test_game", to_rows("test_game", instances_data))
+
+    def _last_reset_options(self):
+        return self.mock_env.reset.call_args[1]["options"]
+
+    def test_sequential_iteration(self):
+        """reset() without game_id advances through instances in order."""
+        wrapper = GameInstanceIteratorWrapper(self.mock_env, self.instances, single_pass=True)
+        wrapper.reset()
+        self.assertEqual(self._last_reset_options()["game_instance"]["game_id"], 1)
+        wrapper.reset()
+        self.assertEqual(self._last_reset_options()["game_instance"]["game_id"], 2)
+
+    def test_single_pass_raises_stop_iteration(self):
+        """Single-pass iterator raises StopIteration after all instances are exhausted."""
+        instances = GameInstances("test_game", to_rows("test_game", {
+            "experiments": [{"name": "exp1", "game_instances": [{"game_id": 1}]}]
+        }))
+        wrapper = GameInstanceIteratorWrapper(self.mock_env, instances, single_pass=True)
+        wrapper.reset()
+        with self.assertRaises(StopIteration):
+            wrapper.reset()
+
+    def test_cycling(self):
+        """Default (non-single-pass) iterator cycles infinitely."""
+        instances = GameInstances("test_game", to_rows("test_game", {
+            "experiments": [{"name": "exp1", "game_instances": [{"game_id": 1}]}]
+        }))
+        wrapper = GameInstanceIteratorWrapper(self.mock_env, instances, single_pass=False)
+        wrapper.reset()
+        wrapper.reset()  # cycles back to start
+        self.assertEqual(self._last_reset_options()["game_instance"]["game_id"], 1)
+
+    def test_game_id_random_access(self):
+        """reset(options={"game_id": N}) selects the specific episode."""
+        wrapper = GameInstanceIteratorWrapper(self.mock_env, self.instances)
+        wrapper.reset(options={"game_id": 3})
+        self.assertEqual(self._last_reset_options()["game_instance"]["game_id"], 3)
+
+    def test_game_id_does_not_advance_iterator(self):
+        """Random access via game_id leaves the iterator position unchanged."""
+        wrapper = GameInstanceIteratorWrapper(self.mock_env, self.instances, single_pass=True)
+        wrapper.reset(options={"game_id": 3})  # random access, iterator not advanced
+        wrapper.reset()  # should still get first instance from iterator
+        self.assertEqual(self._last_reset_options()["game_instance"]["game_id"], 1)
+
+    def test_game_id_not_forwarded_to_env(self):
+        """game_id is consumed by the wrapper and not passed to the underlying env."""
+        wrapper = GameInstanceIteratorWrapper(self.mock_env, self.instances)
+        wrapper.reset(options={"game_id": 1})
+        self.assertNotIn("game_id", self._last_reset_options())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- `GameInstanceIteratorWrapper.reset(options={"game_id": N})` selects an episode by `game_id` directly without advancing the iterator — enabling training loops to replay the same episode until solved
- `game_id` is coerced to `int` in `find_by_game_id()` to handle string values from HTTP callers (e.g. openenv server)
- `ClemGameEnvironment.reset()` now forwards `seed` and any extra kwargs (including `episode_id`) as `options` to the gym env, so `game_id` and future options propagate correctly through the openenv client

## Motivation

A common RL training pattern is to hold the current task until a success criterion is met before advancing to the next one. By supporting `game_id` in `reset()`, the training loop fully controls pacing — no strategy classes needed. The `game_id`-to-`int` coercion handles the reality that HTTP query parameters arrive as strings.

## Changes

- `wrappers.py`: `GameInstanceIteratorWrapper` stores `game_instances` reference; `reset()` pops `game_id` from options and does a direct lookup via `find_by_game_id()` when present, otherwise advances the iterator normally
- `instances.py`: `find_by_game_id()` coerces both the argument and stored `game_id` to `int` before comparison
- `server/environment.py`: `ClemGameEnvironment.reset()` passes `seed` and `options` through to the underlying gym env
- `tests/test_pettingzoo_wrappers.py`: added `GameInstanceIteratorWrapperTestCase` with tests for sequential iteration, single-pass exhaustion, cycling, random access, iterator-position invariance, and non-forwarding of `game_id`
- `tests/test_game_instance_iterator.py`: added test that `find_by_game_id` accepts string inputs

## Test plan

- [x] All existing tests pass (pre-existing HF test failure unrelated)
- [x] `reset()` without `game_id` still cycles/iterates sequentially
- [x] `reset(options={"game_id": N})` replays episode N without advancing the iterator
- [x] `game_id` string coercion works (HTTP callers pass strings)
- [x] `game_id` is not forwarded to the underlying env
- [x] `ClemGameEnvironment.reset(game_id=N)` propagates through to the wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)