### PR TITLE
Fix missing count_request() in DialogueGameMaster.step()

### DIFF
--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -376,6 +376,7 @@ class DialogueGameMaster(GameMaster):
         # Log message exchange (assuming the step response is from the current player and context)
         self.log_gm_to_player(context, self.current_player)
         self.log_player_to_gm(response, self.current_player)
+        self.count_request()
 
         # Consume the initial_prompt (if set) now that we've committed to this turn
         self.initial_prompt_for_player.pop(self.current_player.name, None)

--- a/tests/test_game_master.py
+++ b/tests/test_game_master.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import MagicMock
+
+from clemcore.clemgame.errors import ParseError
+from clemcore.clemgame.events import GameEventLogger
+from clemcore.clemgame.master import DialogueGameMaster
+
+
+def _make_game_master(parse_raises=False):
+    """Create a minimal DialogueGameMaster with a mock logger registered."""
+    game_spec = MagicMock()
+    game_spec.game_name = "test_game"
+    game_spec.game_path = "/tmp"
+    game_spec.players = 1
+
+    class ConcreteGM(DialogueGameMaster):
+        def _on_setup(self, **kwargs):
+            player = MagicMock()
+            player.game_role = "Player"
+            self.add_player(player, initial_context="hello")
+
+        def _parse_response(self, player, response):
+            if parse_raises:
+                raise ParseError("bad format")
+            return response
+
+        def _advance_game(self, player, parsed_response):
+            self.state.succeed()
+
+    gm = ConcreteGM(game_spec, {}, [MagicMock()])
+    gm.setup()
+    gm.before_game()
+
+    mock_logger = MagicMock(spec=GameEventLogger)
+    gm.register(mock_logger)
+    return gm, mock_logger
+
+
+class TestDialogueGameMasterRequestCounting(unittest.TestCase):
+
+    def test_step_counts_request_on_valid_response(self):
+        """count_request() must be called on the GM's loggers for every step."""
+        gm, mock_logger = _make_game_master()
+        gm.step("valid response")
+        mock_logger.count_request.assert_called_once()
+        mock_logger.count_request_violation.assert_not_called()
+
+    def test_step_counts_request_and_violation_on_parse_error(self):
+        """count_request() and count_request_violation() must both be called when parsing fails."""
+        gm, mock_logger = _make_game_master(parse_raises=True)
+        gm.step("bad response")
+        mock_logger.count_request.assert_called_once()
+        mock_logger.count_request_violation.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `DialogueGameMaster.step()` never called `self.count_request()`, causing `METRIC_REQUEST_COUNT`, `METRIC_REQUEST_COUNT_VIOLATED`, and `METRIC_REQUEST_COUNT_PARSED` to always be zero for non-legacy games using `auto_count_logging`
- The bug was introduced in #182 when the single shared `_game_recorder` was refactored into separate recorders per entity — after that, the player's `count_request()` no longer reached the `InteractionsFileSaver` recorder on the GM
- Legacy `DialogueGameMaster` was unaffected because it calls `log_game_end(auto_count_logging=False)` and games log metrics manually

## Fix

Add `self.count_request()` in `step()` alongside the existing log calls, mirroring the `count_request_violation()` already called on the parse error path.

## Test plan

- [x] New test `tests/test_game_master.py` covers both the happy path (valid response → `count_request` called once, no violation) and the parse error path (`count_request` + `count_request_violation` both called once)
- [x] Run `python -m pytest tests/test_game_master.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)