### PR TITLE
Pass clemcore logging config to uvicorn in clem serve

### DIFF
--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -78,7 +78,10 @@ class ClemGameEnvironment(Environment):
         self._state.step_count = 0
         self._state.episode_count += 1
         self._state.episode_id = f"episode_{self._state.episode_count}"
-        module_logger.info(f"Reset ClemGameEnvironment {self._state.game_name} for episode {self._state.episode_id}")
+        module_logger.info(
+            f"Reset ClemGameEnvironment '{self._state.game_name}' for episode '{self._state.episode_id}' "
+            f"with options={options}"
+        )
         return ClemGameObservation(context=observation)
 
     def step(self, action: ClemGameAction, timeout_s=None, **kwargs) -> ClemGameObservation:

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -74,14 +74,14 @@ class ClemGameEnvironment(Environment):
         if episode_id is not None:
             kwargs["episode_id"] = episode_id
         options = kwargs if kwargs else None
-        observation, info = self._game_env.reset(seed=seed, options=options)
-        self._state.step_count = 0
-        self._state.episode_count += 1
-        self._state.episode_id = f"episode_{self._state.episode_count}"
         module_logger.info(
             f"Reset ClemGameEnvironment '{self._state.game_name}' for episode '{self._state.episode_id}' "
             f"with kwargs={kwargs}"
         )
+        observation, info = self._game_env.reset(seed=seed, options=options)
+        self._state.step_count = 0
+        self._state.episode_count += 1
+        self._state.episode_id = f"episode_{self._state.episode_count}"
         return ClemGameObservation(context=observation)
 
     def step(self, action: ClemGameAction, timeout_s=None, **kwargs) -> ClemGameObservation:

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -89,9 +89,9 @@ class ClemGameEnvironment(Environment):
             module_logger.debug(f"Step ClemGameEnvironment with action={action.model_dump()}")
         observation, reward, done, truncated, info = self._game_env.step(action.response)
         if module_logger.isEnabledFor(logging.DEBUG):
-            print(f"Step ClemGameEnvironment result is "
-                  f"observation={observation}, reward={reward}, done={done}, "
-                  f"truncated={truncated}, info={info}")
+            module_logger.debug(f"Step ClemGameEnvironment result is "
+                                f"observation={observation}, reward={reward}, done={done}, "
+                                f"truncated={truncated}, info={info}")
         self._state.step_count += 1
         return ClemGameObservation(
             context=observation,

--- a/clemcore/clemgame/envs/openenv/server/environment.py
+++ b/clemcore/clemgame/envs/openenv/server/environment.py
@@ -80,7 +80,7 @@ class ClemGameEnvironment(Environment):
         self._state.episode_id = f"episode_{self._state.episode_count}"
         module_logger.info(
             f"Reset ClemGameEnvironment '{self._state.game_name}' for episode '{self._state.episode_id}' "
-            f"with options={options}"
+            f"with kwargs={kwargs}"
         )
         return ClemGameObservation(context=observation)
 

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -12,7 +12,7 @@ from clemcore.backends import ModelRegistry, BackendRegistry, Model, KeyRegistry
 from clemcore.clemgame import GameRegistry, GameSpec, InstanceFileSaver, ExperimentFileSaver, \
     InteractionsFileSaver, GameBenchmarkCallbackList, RunFileSaver, GameInstances, ResultsFolder, \
     GameBenchmark
-from clemcore import clemeval, get_version
+from clemcore import clemeval, get_version, load_logging_config
 from clemcore.clemgame.callbacks.files import PlayerFileSaver
 from clemcore.clemgame.runners import dispatch
 from clemcore.clemgame.transcripts.builder import build_transcripts
@@ -276,7 +276,7 @@ def serve(game: str,
         results_dir=results_dir,
         run_id=run_id
     )
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=host, port=port, log_config=load_logging_config())
 
 
 def parse_kv(arg: str):

--- a/clemcore/utils/logging.yaml
+++ b/clemcore/utils/logging.yaml
@@ -28,11 +28,6 @@ loggers:
   "uvicorn":
     level: INFO
     handlers: [ console ]
-  "uvicorn.error":
-    level: INFO
-  "uvicorn.access":
-    level: INFO
-    handlers: [ console ]
   "pettingzoo":
     level: WARNING
     handlers: [ console ]

--- a/clemcore/utils/logging.yaml
+++ b/clemcore/utils/logging.yaml
@@ -30,9 +30,11 @@ loggers:
     handlers: [ console ]
   "uvicorn.error":
     level: INFO
-    handlers: [ console ]
   "uvicorn.access":
     level: INFO
+    handlers: [ console ]
+  "pettingzoo":
+    level: WARNING
     handlers: [ console ]
 root:
   level: INFO

--- a/clemcore/utils/logging.yaml
+++ b/clemcore/utils/logging.yaml
@@ -24,6 +24,16 @@ loggers:
     level: WARNING
   "clemcore.clemgame.envs":
     level: INFO
+    handlers: [ console ]
+  "uvicorn":
+    level: INFO
+    handlers: [ console ]
+  "uvicorn.error":
+    level: INFO
+    handlers: [ console ]
+  "uvicorn.access":
+    level: INFO
+    handlers: [ console ]
 root:
   level: INFO
   handlers: [ file_handler ]

--- a/test.ipynb
+++ b/test.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Uvicorn was calling its own `logging.config.dictConfig` on startup, overriding the clemcore logging config and silencing INFO-level logs from `clemcore.clemgame.envs` (e.g. `reset()` calls in the openenv server)
- Pass `log_config=load_logging_config()` to `uvicorn.run()` so our config wins
- Add `uvicorn` logger to `logging.yaml` using the existing `console` handler — child loggers (`uvicorn.error`, `uvicorn.access`) inherit from it, so HTTP access logs are preserved
- Add `pettingzoo` logger to `logging.yaml` so pettingzoo warnings appear on console
- Log kwargs passed to `ClemGameEnvironment.reset()` to make task selection visible in the console

## Test plan

- [ ] Run `clem serve` and verify `reset` calls (including kwargs) appear in console output
- [ ] Verify HTTP access log lines still appear
- [ ] Verify pettingzoo warnings appear in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)