### PR TITLE
Log game_id consumption and loaded instance in GameInstanceIteratorWrapper.reset()

### DIFF
--- a/clemcore/clemgame/envs/pettingzoo/wrappers.py
+++ b/clemcore/clemgame/envs/pettingzoo/wrappers.py
@@ -236,9 +236,12 @@ class GameInstanceIteratorWrapper(BaseWrapper):
         options = options or {}
         game_id = options.pop("game_id", None)  # consumed here; not forwarded to the underlying game env
         if game_id is not None:
+            stdout_logger.info("Reset requested for game_id=%s", game_id)
             row = self._game_instances.find_by_game_id(game_id)
         else:
             row = next(self._iter)
+        stdout_logger.info("Loading instance: experiment=%s, game_id=%s",
+                           row["experiment"]["name"], row["game_instance"].get("game_id"))
         options["experiment"] = row["experiment"]
         options["game_instance"] = row["game_instance"]
         super().reset(seed=seed, options=options)


### PR DESCRIPTION
## Summary
- Logs when a `game_id` is received and consumed by the wrapper (so users know it was picked up, not silently dropped)
- Logs the resolved experiment name and game_id for every reset, regardless of whether `game_id` was passed explicitly or the iterator advanced

## Test plan
- [x] Manually verify log output when calling `reset()` with a `game_id` option
- [x] Manually verify log output when calling `reset()` without `game_id` (iterator path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)