### PR TITLE
Make numpy an optional dependency

### DIFF
--- a/clemcore/clemgame/instances.py
+++ b/clemcore/clemgame/instances.py
@@ -5,7 +5,12 @@ import os
 import random
 from typing import Dict, final, Callable, List
 
-import numpy as np
+try:
+    import numpy as np
+    _has_numpy = True
+except ImportError:
+    _has_numpy = False
+
 from clemcore.clemgame.registry import GameSpec
 
 from clemcore.clemgame.resources import GameResourceLocator, load_json
@@ -256,7 +261,8 @@ class GameInstanceGenerator(GameResourceLocator):
             kwargs: Keyword arguments (or dict) to pass to the on_generate method.
         """
         random.seed(seed)
-        np.random.seed(seed)
+        if _has_numpy:
+            np.random.seed(seed)
         self.on_generate(seed, **kwargs)
         file_path = self.store_file(self.instances, filename, sub_dir="in")
         return file_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ authors = [
 ]
 dependencies = [
     "pyyaml>=6.0",
-    "numpy>=1.24.3,<2.0.0",
     "retry>=0.9.2",
     "tqdm>=4.65.0",
     "nltk>=3.9.2,<4.0.0", # for featstruct.unify (3.9 fixes CVE-2024-39705)


### PR DESCRIPTION
## Summary

- Remove `numpy>=1.24.3,<2.0.0` from `pyproject.toml` dependencies
- Guard `np.random.seed()` in `instances.py` with a try/except import so numpy is not required at runtime
- numpy is still available in practice as a transitive dependency of pandas, pettingzoo, etc.

## Why

The `<2.0.0` upper bound was blocking numpy 2.x adoption across the ecosystem. Since clemcore only uses numpy for `np.random.seed()` in `GameInstanceIterator.generate()` (seeding RNG for reproducible instance generation), making it optional is straightforward.

With numpy removed as a direct dependency, pip is free to resolve whatever numpy version satisfies the transitive requirements — including numpy 2.x when packages like vLLM and transformers require it.

## Behaviour

- If numpy is installed (which it always will be as a transitive dep of pandas): `np.random.seed(seed)` is called alongside `random.seed(seed)` as before
- If numpy is not installed: only `random.seed(seed)` is called — no error

## Test results

265 passed, 0 failures across the full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)