### PR TITLE
Bump transformers to >=5.0.0

### DIFF
--- a/clemcore/backends/huggingface_local_api.py
+++ b/clemcore/backends/huggingface_local_api.py
@@ -102,7 +102,7 @@ def load_config_and_tokenizer(model_spec: backends.ModelSpec) -> Tuple[PreTraine
         else:
             requires_api_key_info = (f"{model_spec['model_name']} registry setting has requires_api_key, "
                                      f"but it is not 'true'. Please check the model entry.")
-            print(requires_api_key_info)
+            stdout_logger.info(requires_api_key_info)
             logger.info(requires_api_key_info)
 
     hf_model_str = model_spec['huggingface_id']
@@ -426,14 +426,16 @@ class HuggingfaceLocalModel(backends.BatchGenerativeModel):
             gen_args["max_new_tokens"] = self.context_size
 
         # Put the model into evaluation mode e.g., disable dropout and configure batch norm etc.
-        self.model.eval()
+        if self.model.training:
+            stdout_logger.info("Model is in training mode; switching to eval mode for generation.")
+            self.model.eval()
 
         # Generate outputs for the whole batch (Note: model.generate() is decorated with torch.no_grad() !)
         generation_output: GenerateOutput = self.model.generate(prompt_token_ids, **gen_args)
 
         # Decode all outputs and prompts
-        model_outputs = self.tokenizer.batch_decode(generation_output.sequences)
-        prompt_texts = self.tokenizer.batch_decode(prompt_token_ids)
+        model_outputs = self.tokenizer.decode(generation_output.sequences)
+        prompt_texts = self.tokenizer.decode(prompt_token_ids)
 
         prompts, response_texts, responses = split_and_clean_batch_outputs(self,
                                                                            model_outputs,

--- a/clemcore/backends/huggingface_local_api.py
+++ b/clemcore/backends/huggingface_local_api.py
@@ -294,7 +294,7 @@ class HuggingfaceLocalModel(backends.BatchGenerativeModel):
             # set pad_token_id to tokenizer's eos_token_id to prevent excessive warnings:
             self.model.generation_config.pad_token_id = self.tokenizer.eos_token_id
 
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = next(self.model.parameters()).device
 
     @property
     def chat_template_kwargs(self) -> dict:

--- a/clemcore/backends/huggingface_local_api.py
+++ b/clemcore/backends/huggingface_local_api.py
@@ -107,20 +107,7 @@ def load_config_and_tokenizer(model_spec: backends.ModelSpec) -> Tuple[PreTraine
 
     hf_model_str = model_spec['huggingface_id']
 
-    # use 'slow' tokenizer for models that require it:
-    if 'slow_tokenizer' in model_spec.model_config:
-        if model_spec['model_config']['slow_tokenizer']:
-            tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
-                hf_model_str,
-                use_fast=False
-            )
-        else:
-            tokenizer = None
-            slow_tokenizer_info = (f"{model_spec['model_name']} registry setting has slow_tokenizer, "
-                                   f"but it is not 'true'. Please check the model entry.")
-            print(slow_tokenizer_info)
-            logger.info(slow_tokenizer_info)
-    elif use_api_key:
+    if use_api_key:
         tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
             hf_model_str,
             token=api_key,

--- a/clemcore/backends/huggingface_local_api.py
+++ b/clemcore/backends/huggingface_local_api.py
@@ -5,7 +5,7 @@ import logging
 from typing import List, Dict, Tuple, Any
 import torch
 import re
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig, PreTrainedTokenizerBase, PreTrainedModel
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig, BitsAndBytesConfig, PreTrainedTokenizerBase, PreTrainedModel
 from transformers.generation.utils import GenerateOutput
 from peft import PeftModel
 from jinja2 import TemplateError
@@ -112,9 +112,6 @@ def load_config_and_tokenizer(model_spec: backends.ModelSpec) -> Tuple[PreTraine
         if model_spec['model_config']['slow_tokenizer']:
             tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
                 hf_model_str,
-                device_map="auto",
-                torch_dtype="auto",
-                verbose=False,
                 use_fast=False
             )
         else:
@@ -127,16 +124,10 @@ def load_config_and_tokenizer(model_spec: backends.ModelSpec) -> Tuple[PreTraine
         tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
             hf_model_str,
             token=api_key,
-            device_map="auto",
-            torch_dtype="auto",
-            verbose=False
         )
     else:
         tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
             hf_model_str,
-            device_map="auto",
-            torch_dtype="auto",
-            verbose=False
         )
 
     # apply proper chat template:
@@ -233,10 +224,13 @@ def load_model(model_spec: backends.ModelSpec) -> PreTrainedModel | PeftModel:
     logger.info(f'Start loading huggingface model weights: {model_spec.model_name}')
 
     model_args = dict(device_map="auto", torch_dtype="auto")
+    bnb_kwargs = {}
     if "load_in_8bit" in model_spec.model_config:
-        model_args["load_in_8bit"] = model_spec.model_config["load_in_8bit"]
+        bnb_kwargs["load_in_8bit"] = model_spec.model_config["load_in_8bit"]
     if "load_in_4bit" in model_spec.model_config:
-        model_args["load_in_4bit"] = model_spec.model_config["load_in_4bit"]
+        bnb_kwargs["load_in_4bit"] = model_spec.model_config["load_in_4bit"]
+    if bnb_kwargs:
+        model_args["quantization_config"] = BitsAndBytesConfig(**bnb_kwargs)
     if 'requires_api_key' in model_spec.model_config and model_spec['model_config']['requires_api_key']:
         # load HF API key:
         key = KeyRegistry.from_json().get_key_for("huggingface")
@@ -728,7 +722,10 @@ def check_context_limit(messages: List[Dict], model_spec: backends.ModelSpec,
     else:
         current_messages = messages
     # the actual tokens, including chat format:
+    # transformers >=5: apply_chat_template returns BatchEncoding when tokenize=True
     prompt_tokens = tokenizer.apply_chat_template(current_messages, add_generation_prompt=True)
+    if hasattr(prompt_tokens, 'input_ids'):
+        prompt_tokens = prompt_tokens.input_ids
     context_check_tuple = _check_context_limit(context_size, prompt_tokens, max_new_tokens=max_new_tokens)
     tokens_used = context_check_tuple[1]
     tokens_left = context_check_tuple[2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,9 @@ dependencies = [
 
 [project.optional-dependencies]
 huggingface = [
-    "accelerate>=1.0.0,<2.0.0", # required for device_map="auto"
+    "accelerate", # required for device_map="auto"; version compatibility managed by transformers
     "bitsandbytes>=0.42.0,<1.0.0", # for loading models with 4-bit and 8-bit quantization
-    "peft>=0.17.0,<1.0.0", # for loading LoRA models (adapters)
-    "timm>=1.0.19,<1.1.0", # for transformers
+    "peft>=0.18.0,<1.0.0", # for loading LoRA models (adapters)
     "transformers>=5.0.0,<6.0.0", # installs torch
     "torchvision", # version resolved by torch
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ dependencies = [
 
 [project.optional-dependencies]
 huggingface = [
-    "accelerate", # required for device_map="auto"; version compatibility managed by transformers
-    "bitsandbytes>=0.42.0,<1.0.0", # for loading models with 4-bit and 8-bit quantization
-    "peft>=0.18.0,<1.0.0", # for loading LoRA models (adapters)
     "transformers>=5.0.0,<6.0.0", # installs torch
+    "accelerate", # required for device_map="auto"; version compatibility managed by transformers
+    "bitsandbytes", # for loading models with 4-bit and 8-bit quantization
+    "peft", # for loading LoRA models (adapters)
     "torchvision", # version resolved by torch
 ]
 slurk = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ huggingface = [
     "bitsandbytes>=0.42.0,<1.0.0", # for loading models with 4-bit and 8-bit quantization
     "peft>=0.17.0,<1.0.0", # for loading LoRA models (adapters)
     "timm>=1.0.19,<1.1.0", # for transformers
-    "transformers>=4.55.2,<5.0.0", # installs torch
+    "transformers>=5.0.0,<6.0.0", # installs torch
     "torchvision", # version resolved by torch
 ]
 slurk = [


### PR DESCRIPTION
## Summary

Bumps transformers to v5 and cleans up the huggingface backend accordingly.

**`pyproject.toml`**
- Pin `transformers>=5.0.0,<6.0.0`
- Drop `timm` (not imported anywhere; transitive dep for vision models only)
- Drop version bounds from `accelerate`, `peft`, `bitsandbytes` — transformers only specifies lower bounds for these, so bare names let pip resolve latest compatible versions; version compat is managed by the HF ecosystem
- Reorder: `transformers` first as the anchor

**`huggingface_local_api.py`** — v5 API fixes:
- `load_in_8bit` / `load_in_4bit` direct `from_pretrained` kwargs removed in v5 — now passed via `BitsAndBytesConfig`
- `device_map`, `torch_dtype`, `verbose` removed from `AutoTokenizer.from_pretrained` (model-only kwargs, silently ignored in v4)
- `apply_chat_template(tokenize=True)` returns `BatchEncoding` in v5 — `check_context_limit` now extracts `.input_ids` when needed
- Slow tokenizer branch removed (`use_fast` / slow tokenizer split was dropped in v5 PR #40936; `slow_tokenizer` key was unused in model registry anyway)
- `batch_decode` replaced with `decode` (unified in v5)

**`huggingface_local_api.py`** — other cleanups:
- `self.device` now derived from `next(self.model.parameters()).device` instead of `torch.cuda.is_available()` — correctly handles multi-GPU `device_map="auto"` setups
- `model.eval()` only called when model is actually in training mode, with a `stdout_logger` notice
- `print` replaced with `stdout_logger` for the `requires_api_key` misconfiguration warning

## Test plan

- [ ] `python -m pytest tests/` passes
- [ ] Load a quantized model with `load_in_4bit: true` in its model config and verify it loads correctly
- [ ] Run `check_context_limit` against a local model and confirm token counts are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)