### PR TITLE
Add CLI improvements for release 3.7

### DIFF
--- a/clemcore/clemeval.py
+++ b/clemcore/clemeval.py
@@ -32,8 +32,14 @@ class PlayedScoreError(Exception):
     pass
 
 
-def save_clem_table(df: pd.DataFrame, path: str) -> pd.DataFrame | None:
-    """Create benchmark results as a table."""
+def save_clem_table(df: pd.DataFrame, path: str, show_std: bool = False, sort_by: str = "model_name") -> pd.DataFrame | None:
+    """Create benchmark results as a table.
+    Args:
+        df: Episode scores dataframe.
+        path: Directory path to save the results files.
+        show_std: If True, include standard deviation columns for Quality Score. Default: False.
+        sort_by: Sort rows by 'model_name' (alphabetical) or 'clemscore' (descending). Default: 'model_name'.
+    """
 
     # extract only relevant metrics
     df = df[df['metric'].isin(MAIN_METRICS)]
@@ -51,15 +57,6 @@ def save_clem_table(df: pd.DataFrame, path: str) -> pd.DataFrame | None:
     df_a['metric'] = df_a['metric'].replace(
         {clemmetrics.METRIC_PLAYED: '% ' + clemmetrics.METRIC_PLAYED})
 
-    # compute the std of benchscore
-    df = df[df.metric == clemmetrics.BENCH_SCORE]
-    df_b = (df.groupby(['game', 'model', 'metric'])
-            .std(numeric_only=True)
-            .reset_index()
-            .round(2))
-    df_b['metric'] = df_b['metric'].replace(
-        {clemmetrics.BENCH_SCORE: clemmetrics.BENCH_SCORE + ' (std)'})
-
     # compute the macro-average main score over games, per model
     df_all = (df_a.groupby(['model', 'metric'])
               .mean(numeric_only=True)
@@ -69,8 +66,21 @@ def save_clem_table(df: pd.DataFrame, path: str) -> pd.DataFrame | None:
     df_all['game'] = 'all'
     df_all['metric'] = 'Average ' + df_all['metric']
 
+    parts = [df_a, df_all]
+
+    if show_std:
+        # compute the std of benchscore
+        df_std = df[df.metric == clemmetrics.BENCH_SCORE]
+        df_b = (df_std.groupby(['game', 'model', 'metric'])
+                .std(numeric_only=True)
+                .reset_index()
+                .round(2))
+        df_b['metric'] = df_b['metric'].replace(
+            {clemmetrics.BENCH_SCORE: clemmetrics.BENCH_SCORE + ' (std)'})
+        parts.insert(1, df_b)
+
     # merge all data and make it one model per row
-    df_full = pd.concat([df_a, df_b, df_all], axis=0, ignore_index=True)
+    df_full = pd.concat(parts, axis=0, ignore_index=True)
     # sort just so all metrics are close to each other in a game column
     df_full.sort_values(by=['game', 'metric'], inplace=True)
     # rename according to paper
@@ -88,6 +98,12 @@ def save_clem_table(df: pd.DataFrame, path: str) -> pd.DataFrame | None:
     df_results.index.name = None
     df_results.columns = df_results.columns.to_flat_index()
     df_results.columns = [', '.join(x) for x in df_results.columns]
+
+    # sort rows
+    if sort_by == "clemscore":
+        df_results.sort_values(by='-, clemscore', ascending=False, inplace=True)
+    else:
+        df_results.sort_index(inplace=True)
 
     # save table
     df_results.to_csv(Path(path) / f'{TABLE_NAME}.csv')
@@ -150,7 +166,8 @@ def build_df_episode_scores(scores: dict) -> pd.DataFrame:
     return df_episode_scores
 
 
-def perform_evaluation(results_path: str, return_dataframe: bool = False) -> pd.DataFrame | None:
+def perform_evaluation(results_path: str, return_dataframe: bool = False,
+                       show_std: bool = False, sort_by: str = "model_name") -> pd.DataFrame | None:
     # Get all episode scores as a pandas dataframe
     scores = load_scores(path=results_path)
     df_episode_scores = build_df_episode_scores(scores)
@@ -169,6 +186,6 @@ def perform_evaluation(results_path: str, return_dataframe: bool = False) -> pd.
     print(f'\n Saved raw scores into {results_path}/raw.csv')
 
     # save main table
-    df_episode_scores = save_clem_table(df_episode_scores, results_path)
+    df_episode_scores = save_clem_table(df_episode_scores, results_path, show_std=show_std, sort_by=sort_by)
     if return_dataframe:
         return df_episode_scores

--- a/clemcore/clemgame/benchmark.py
+++ b/clemcore/clemgame/benchmark.py
@@ -59,18 +59,20 @@ class GameBenchmark(GameResourceLocator):
         self.close()
         return False
 
-    def compute_scores(self, results_dir: str):
+    def compute_scores(self, results_dir: str, model_selector: str = None):
         """Compute and store scores for each episode and player pair.
         Episode score JSON files are stored in each corresponding episode directory. Combined scores for a player/model
         pair are stored in the player pair directory.
         Args:
             results_dir: Path to the results directory.
+            model_selector: Optional model name to restrict scoring to a specific model's results.
         """
         results_root = results_dir
         filter_games = [self.game_name]
         interaction_files = [
             f for f in glob.glob(os.path.join(results_root, '**', 'interactions.json'), recursive=True)
             if any(game_name in Path(f).parts for game_name in filter_games)
+            and (model_selector is None or model_selector in Path(f).parts)
         ]
         stdout_logger.info(f"Found {len(interaction_files)} interaction files to score. "
                            f"Games: {filter_games if filter_games else 'all'}")

--- a/clemcore/clemgame/registry.py
+++ b/clemcore/clemgame/registry.py
@@ -69,6 +69,14 @@ class GameSpec(SimpleNamespace):
         """
         return hasattr(self, attribute)
 
+    def __eq__(self, other):
+        if not isinstance(other, GameSpec):
+            return NotImplemented
+        return self.game_name == other.game_name
+
+    def __hash__(self):
+        return hash(self.game_name)
+
     def to_string(self):
         return json.dumps(self.__dict__, separators=(",", ":"), indent=None)
 

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -132,7 +132,7 @@ def list_games(game_selector: str, verbose: bool = False):
             print(game_name, wrapper.fill(game_spec["description"]))
 
 
-def run(game_selector: Union[str, Dict, GameSpec],
+def run(game_selectors: Union[str, Dict, GameSpec, List[Union[str, Dict, GameSpec]]],
         model_selectors: List[backends.ModelSpec],
         *,
         gen_args: Dict,
@@ -144,7 +144,8 @@ def run(game_selector: Union[str, Dict, GameSpec],
         ):
     """Run specific model/models with a specified clemgame.
     Args:
-        game_selector: Name of the game, matching the game's name in the game registry, OR GameSpec-like dict, OR GameSpec.
+        game_selectors: One or more game selectors. Each can be a game name, a GameSpec-like dict, or a GameSpec.
+            Pass a list to run multiple games in a single invocation.
         model_selectors: One or two selectors for the models that are supposed to play the games.
         gen_args: Text generation parameters for the backend; output length and temperature are implemented for the
             majority of model backends.
@@ -156,8 +157,13 @@ def run(game_selector: Union[str, Dict, GameSpec],
         batch_size: A batch size to use for the run.
     """
     # check games
+    if not isinstance(game_selectors, list):
+        game_selectors = [game_selectors]
     game_registry = GameRegistry.from_directories_and_cwd_files()
-    game_specs = game_registry.get_game_specs_that_unify_with(game_selector)  # throws error when nothing unifies
+    game_specs = set()
+    for game_selector in game_selectors:
+        game_specs.update(game_registry.get_game_specs_that_unify_with(game_selector))  # throws error when nothing unifies
+    game_specs = list(game_specs)
 
     # load models (can take some time for large local models)
     player_models = backends.load_models(model_selectors, gen_args)
@@ -212,13 +218,12 @@ def run(game_selector: Union[str, Dict, GameSpec],
         sys.exit(1)
 
 
-def score(game_selector: Union[str, Dict, GameSpec], results_dir: str = None):
+def score(game_selector: Union[str, Dict, GameSpec], results_dir: str = None, model_selector: str = None):
     """Calculate scores from a game benchmark run's records and store score files.
     Args:
         game_selector: Name of the game, matching the game's name in the game registry, OR GameSpec-like dict, OR GameSpec.
-        experiment_name: Name of the experiment to score. Corresponds to the experiment directory in each player pair
-            subdirectory in the results directory.
         results_dir: Path to the results directory in which the benchmark records are stored.
+        model_selector: Optional model name to restrict scoring to a specific model.
     """
     logger.info(f"Scoring game {game_selector}")
     errors = []
@@ -228,7 +233,7 @@ def score(game_selector: Union[str, Dict, GameSpec], results_dir: str = None):
         try:
             time_start = datetime.now()
             with GameBenchmark.load_from_spec(game_spec) as game_benchmark:
-                game_benchmark.compute_scores(results_dir)
+                game_benchmark.compute_scores(results_dir, model_selector=model_selector)
             logger.info(f"Scoring {game_benchmark.game_name} took: %s", datetime.now() - time_start)
         except Exception as e:
             logger.exception(e)
@@ -329,6 +334,7 @@ def cli(args: argparse.Namespace):
                 batch_size=args.batch_size)
         finally:
             logger.info("clem run took: %s", datetime.now() - start)
+
     if args.command_name == "serve":
         serve(args.game,
               learner_agent=args.learner_agent,
@@ -341,11 +347,11 @@ def cli(args: argparse.Namespace):
               results_dir=args.results_dir,
               run_id=args.run_id)
     if args.command_name == "score":
-        score(args.game, results_dir=args.results_dir)
+        score(args.game, results_dir=args.results_dir, model_selector=args.model)
     if args.command_name == "transcribe":
         transcripts(args.game, results_dir=args.results_dir)
     if args.command_name == "eval":
-        clemeval.perform_evaluation(args.results_dir)
+        clemeval.perform_evaluation(args.results_dir, show_std=args.std, sort_by=args.sort)
 
 
 def main():
@@ -406,8 +412,21 @@ Update Behavior:
       Default: None.""")
     run_parser.add_argument("-e", "--experiment_name", type=str,
                             help="Optional argument to only run a specific experiment")
-    run_parser.add_argument("-g", "--game", type=str,
-                            required=True, help="A specific game name (see ls), or a GameSpec-like JSON string object.")
+    run_parser.add_argument("-g", "--game", type=str, nargs="+",
+                            required=True, help="""One or more game selectors. Duplicates are ignored.
+
+      Run a single game by name:
+      $> clem run -g taboo -m mock
+
+      Run multiple games in a single invocation:
+      $> clem run -g taboo wordle imagegame -m mock
+
+      Select games by GameSpec-like JSON dict for unification (e.g. by benchmark version):
+      $> clem run -g "{'benchmark':['2.0']}" -m llama3-8b-sft
+
+      Mix names and JSON dicts freely:
+      $> clem run -g taboo "{'benchmark':['2.0']}" -m mock
+      """)
     run_parser.add_argument("-t", "--temperature", type=float, default=0.0,
                             help="Argument to specify sampling temperature for the models. Default: 0.0.")
     run_parser.add_argument("-l", "--max_tokens", type=int, default=300,
@@ -424,16 +443,18 @@ Update Behavior:
                             help="The instances file name (.json suffix will be added automatically.")
     run_parser.add_argument("-r", "--results_dir", type=Path, default="results",
                             help="A relative or absolute path to the results root directory. "
-                                 "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                 "For example '-r results/v1.5/de' or '-r /absolute/path/for/results'. "
                                  "When not specified, then the results will be located in 'results'")
 
     score_parser = sub_parsers.add_parser("score")
     score_parser.add_argument("-g", "--game", type=str,
                               help='A specific game name, a GameSpec-like JSON string object or "all" (default).',
                               default="all")
+    score_parser.add_argument("-m", "--model", type=str, default=None,
+                              help="Optional model name to restrict scoring to a specific model's results.")
     score_parser.add_argument("-r", "--results_dir", type=str, default="results",
                               help="A relative or absolute path to the results root directory. "
-                                   "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                   "For example '-r results/v1.5/de' or '-r /absolute/path/for/results'. "
                                    "When not specified, then the results will be located in 'results'")
 
     transcribe_parser = sub_parsers.add_parser("transcribe")
@@ -442,15 +463,19 @@ Update Behavior:
                                    default="all")
     transcribe_parser.add_argument("-r", "--results_dir", type=str, default="results",
                                    help="A relative or absolute path to the results root directory. "
-                                        "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                        "For example '-r results/v1.5/de' or '-r /absolute/path/for/results'. "
                                         "When not specified, then the results will be located in 'results'")
 
     eval_parser = sub_parsers.add_parser("eval")
     eval_parser.add_argument("-r", "--results_dir", type=str, default="results",
                              help="A relative or absolute path to the results root directory. "
-                                  "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
+                                  "For example '-r results/v1.5/de' or '-r /absolute/path/for/results'. "
                                   "When not specified, then the results will be located in 'results'."
                                   "For evaluation, the directory must already contain the scores.")
+    eval_parser.add_argument("--std", action="store_true",
+                             help="Include standard deviation columns in the results table. Default: off.")
+    eval_parser.add_argument("--sort", type=str, choices=["model_name", "clemscore"], default="model_name",
+                             help="Sort results by model name or clemscore. Default: model_name.")
 
     serve_parser = sub_parsers.add_parser("serve")
     serve_parser.add_argument("-g", "--game",

--- a/tests/test_clemeval.py
+++ b/tests/test_clemeval.py
@@ -164,6 +164,61 @@ class TestPerformEvaluation(unittest.TestCase):
             clemeval.build_df_episode_scores = original_build
 
 
+class TestSaveClemTableStdFlag(unittest.TestCase):
+
+    def setUp(self):
+        # Two episodes so std is meaningful
+        rows = [
+            {'game': 'taboo', 'model': 'gpt-4', 'experiment': 'exp1', 'episode': 'episode_1',
+             'metric': clemmetrics.METRIC_ABORTED, 'value': 0},
+            {'game': 'taboo', 'model': 'gpt-4', 'experiment': 'exp1', 'episode': 'episode_1',
+             'metric': clemmetrics.BENCH_SCORE, 'value': 80},
+            {'game': 'taboo', 'model': 'gpt-4', 'experiment': 'exp1', 'episode': 'episode_2',
+             'metric': clemmetrics.METRIC_ABORTED, 'value': 0},
+            {'game': 'taboo', 'model': 'gpt-4', 'experiment': 'exp1', 'episode': 'episode_2',
+             'metric': clemmetrics.BENCH_SCORE, 'value': 60},
+        ]
+        self.df = _add_played_column(_make_episode_scores_df(rows))
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_std_columns_absent_by_default(self):
+        result = save_clem_table(self.df.copy(), self.tmpdir)
+        std_cols = [c for c in result.columns if '(std)' in c]
+        self.assertEqual(std_cols, [], f"Expected no std columns by default, got {std_cols}")
+
+    def test_std_columns_present_when_requested(self):
+        result = save_clem_table(self.df.copy(), self.tmpdir, show_std=True)
+        std_cols = [c for c in result.columns if '(std)' in c]
+        self.assertGreater(len(std_cols), 0, "Expected at least one std column when show_std=True")
+
+
+class TestSaveClemTableSortFlag(unittest.TestCase):
+
+    def setUp(self):
+        rows = []
+        for model, score in [('z-model', 10), ('a-model', 90), ('m-model', 50)]:
+            for ep in ['episode_1', 'episode_2']:
+                rows += [
+                    {'game': 'taboo', 'model': model, 'experiment': 'exp1', 'episode': ep,
+                     'metric': clemmetrics.METRIC_ABORTED, 'value': 0},
+                    {'game': 'taboo', 'model': model, 'experiment': 'exp1', 'episode': ep,
+                     'metric': clemmetrics.BENCH_SCORE, 'value': score},
+                ]
+        self.df = _add_played_column(_make_episode_scores_df(rows))
+        self.tmpdir = tempfile.mkdtemp()
+
+    def test_sort_by_model_name_default(self):
+        result = save_clem_table(self.df.copy(), self.tmpdir, sort_by='model_name')
+        self.assertEqual(list(result.index), sorted(result.index.tolist()))
+
+    def test_sort_by_clemscore_descending(self):
+        result = save_clem_table(self.df.copy(), self.tmpdir, sort_by='clemscore')
+        clemscore_col = [c for c in result.columns if 'clemscore' in c][0]
+        scores = result[clemscore_col].tolist()
+        self.assertEqual(scores, sorted(scores, reverse=True))
+        self.assertEqual(result.index[0], 'a-model')
+
+
 class TestGoldenOutput(unittest.TestCase):
     """Regression test against real clembench-runs data.
 

--- a/tests/test_clemeval.py
+++ b/tests/test_clemeval.py
@@ -185,7 +185,7 @@ class TestGoldenOutput(unittest.TestCase):
             df = pd.concat([df, aux], ignore_index=True)
 
             with tempfile.TemporaryDirectory() as out_dir:
-                save_clem_table(df, out_dir)
+                save_clem_table(df, out_dir, show_std=True)
                 actual = pd.read_csv(Path(out_dir) / "results.csv", index_col=0)
 
         golden = pd.read_csv(GOLDEN_CSV, index_col=0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 import unittest
-from unittest.mock import patch
+from contextlib import ExitStack
+from unittest.mock import patch, MagicMock
 
-from clemcore.cli import main
+from clemcore.cli import main, score, run
+from clemcore.clemgame.registry import GameSpec
 
 
 class CLIExceptionLoggingTestCase(unittest.TestCase):
@@ -19,6 +21,109 @@ class CLIExceptionLoggingTestCase(unittest.TestCase):
 
                 # Verify logger.exception was called with the exception
                 mock_logger.exception.assert_called_once()
+
+
+class ScoreModelSelectorTestCase(unittest.TestCase):
+    """Test that clem score -m filters scoring to the specified model."""
+
+    def _make_spec(self, name="taboo"):
+        return GameSpec(game_name=name, game_path="/path", players=1)
+
+    def test_model_selector_passed_to_compute_scores(self):
+        mock_benchmark = MagicMock()
+        mock_benchmark.game_name = "taboo"
+        mock_benchmark.__enter__ = lambda s: s
+        mock_benchmark.__exit__ = MagicMock(return_value=False)
+
+        with patch("clemcore.cli.GameRegistry") as mock_registry_cls:
+            mock_registry = mock_registry_cls.from_directories_and_cwd_files.return_value
+            mock_registry.get_game_specs_that_unify_with.return_value = [self._make_spec()]
+            with patch("clemcore.cli.GameBenchmark") as mock_benchmark_cls:
+                mock_benchmark_cls.load_from_spec.return_value = mock_benchmark
+
+                score("taboo", results_dir="results", model_selector="gpt-4o")
+
+        mock_benchmark.compute_scores.assert_called_once_with("results", model_selector="gpt-4o")
+
+    def test_no_model_selector_passes_none(self):
+        mock_benchmark = MagicMock()
+        mock_benchmark.game_name = "taboo"
+        mock_benchmark.__enter__ = lambda s: s
+        mock_benchmark.__exit__ = MagicMock(return_value=False)
+
+        with patch("clemcore.cli.GameRegistry") as mock_registry_cls:
+            mock_registry = mock_registry_cls.from_directories_and_cwd_files.return_value
+            mock_registry.get_game_specs_that_unify_with.return_value = [self._make_spec()]
+            with patch("clemcore.cli.GameBenchmark") as mock_benchmark_cls:
+                mock_benchmark_cls.load_from_spec.return_value = mock_benchmark
+
+                score("taboo", results_dir="results")
+
+        mock_benchmark.compute_scores.assert_called_once_with("results", model_selector=None)
+
+
+class RunGameDeduplicationTestCase(unittest.TestCase):
+    """Test that duplicate game selectors don't result in duplicate game runs."""
+
+    def _make_spec(self, name):
+        return GameSpec(game_name=name, game_path="/path", players=1)
+
+    _IO_PATCHES = [
+        "clemcore.cli.backends.load_models",
+        "clemcore.cli.dispatch.run",
+        "clemcore.cli.ResultsFolder",
+        "clemcore.cli.Model",
+        "clemcore.cli.GameBenchmarkCallbackList",
+        "clemcore.cli.InstanceFileSaver",
+        "clemcore.cli.ExperimentFileSaver",
+        "clemcore.cli.InteractionsFileSaver",
+        "clemcore.cli.RunFileSaver",
+        "clemcore.cli.PlayerFileSaver",
+        "clemcore.cli.GameInstances",
+    ]
+
+    def _run(self, game_selectors):
+        """Call cli.run() with all I/O side effects suppressed."""
+        with ExitStack() as stack:
+            for target in self._IO_PATCHES:
+                kw = {"return_value": [MagicMock()]} if "load_models" in target else {}
+                stack.enter_context(patch(target, **kw))
+            run(game_selectors, model_selectors=[], gen_args={})
+
+    def test_duplicate_game_selectors_run_once(self):
+        mock_benchmark = MagicMock()
+        mock_benchmark.__enter__ = lambda s: s
+        mock_benchmark.__exit__ = MagicMock(return_value=False)
+
+        with patch("clemcore.cli.GameRegistry") as mock_registry_cls:
+            mock_registry = mock_registry_cls.from_directories_and_cwd_files.return_value
+            mock_registry.get_game_specs_that_unify_with.return_value = [self._make_spec("taboo")]
+            with patch("clemcore.cli.GameBenchmark") as mock_benchmark_cls:
+                mock_benchmark_cls.load_from_spec.return_value = mock_benchmark
+                self._run(["taboo", "taboo"])
+
+        # get_game_specs called twice (once per selector) but benchmark loaded once
+        self.assertEqual(mock_benchmark_cls.load_from_spec.call_count, 1)
+
+    def test_distinct_game_selectors_each_run(self):
+        taboo = self._make_spec("taboo")
+        wordle = self._make_spec("wordle")
+
+        mock_benchmark = MagicMock()
+        mock_benchmark.__enter__ = lambda s: s
+        mock_benchmark.__exit__ = MagicMock(return_value=False)
+
+        def specs_for(selector):
+            return [taboo] if selector == "taboo" else [wordle]
+
+        with patch("clemcore.cli.GameRegistry") as mock_registry_cls:
+            mock_registry = mock_registry_cls.from_directories_and_cwd_files.return_value
+            mock_registry.get_game_specs_that_unify_with.side_effect = specs_for
+            with patch("clemcore.cli.GameBenchmark") as mock_benchmark_cls:
+                mock_benchmark_cls.load_from_spec.return_value = mock_benchmark
+                self._run(["taboo", "wordle"])
+
+        self.assertEqual(mock_benchmark_cls.load_from_spec.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_game_spec.py
+++ b/tests/test_game_spec.py
@@ -188,5 +188,37 @@ class GameSpecTestCase(unittest.TestCase):
             self.assertEqual(specs[1].game_name, "game_b")
 
 
+class GameSpecHashEqTestCase(unittest.TestCase):
+
+    def _make(self, name):
+        return GameSpec(game_name=name, game_path="/path", players=1)
+
+    def test_equal_same_name(self):
+        self.assertEqual(self._make("taboo"), self._make("taboo"))
+
+    def test_not_equal_different_name(self):
+        self.assertNotEqual(self._make("taboo"), self._make("wordle"))
+
+    def test_hashable(self):
+        spec = self._make("taboo")
+        self.assertIsInstance(hash(spec), int)
+
+    def test_same_name_deduplicates_in_set(self):
+        specs = {self._make("taboo"), self._make("taboo"), self._make("wordle")}
+        self.assertEqual(len(specs), 2)
+
+    def test_duplicate_selectors_deduplicated_via_set(self):
+        """Simulates clem run -g taboo taboo: expanding two identical selectors
+        and collecting into a set should yield a single game spec."""
+        expanded = [self._make("taboo"), self._make("taboo")]
+        result = set(expanded)
+        self.assertEqual(len(result), 1)
+
+    def test_not_equal_to_non_gamespec(self):
+        spec = self._make("taboo")
+        self.assertNotEqual(spec, "taboo")
+        self.assertNotEqual(spec, None)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

| Issue | Change | Files |
|-------|--------|-------|
| #173 | `clem run -g game1 game2 ...` — `-g` now takes multiple values; duplicates removed via `GameSpec.__hash__` | `cli.py`, `registry.py` |
| #242 | `clem score -m <model>` — filters interaction files by model directory name | `cli.py`, `benchmark.py` |
| #235 | `clem eval --std` — std deviation columns are opt-in (default off) | `cli.py`, `clemeval.py` |
| #236 | `clem eval --sort [model_name\|clemscore]` — sorts rows before saving | `cli.py`, `clemeval.py` |

`GameSpec` is now hashable and equal by `game_name`, making `set()` the natural deduplication mechanism for game specs.

The `-g` help text also documents the JSON dict unification syntax:
```
clem run -g "{'benchmark':['2.0']}" -m llama3-8b-sft
```

## Tests added

| File | Tests |
|------|-------|
| `test_game_spec.py` | `GameSpec` equality by name, hashability, `set()` deduplication (6 tests) |
| `test_clemeval.py` | `--std` absent by default, present when requested (2 tests) |
| `test_clemeval.py` | `--sort` alphabetical by model name, descending by clemscore (2 tests) |
| `test_cli.py` | `model_selector` threaded through to `compute_scores` (2 tests) |
| `test_cli.py` | duplicate selectors run once, distinct selectors each run (2 tests) |

## Test plan

- [ ] All existing tests pass (7 pre-existing `test_huggingface_local_api` failures unrelated to this PR)
- [ ] Golden output test updated to explicitly pass `show_std=True` to match existing golden CSV
- [x] `clem run -g taboo taboo -m mock` runs taboo only once
- [x] `clem run -g taboo wordle -m mock` runs both games with models loaded once
- [ ] `clem score -g taboo -m gpt-4o` only scores the specified model's result directories
- [x] `clem eval` without `--std` produces a narrower table without std columns
- [x] `clem eval --sort clemscore` produces table sorted by clemscore descending

🤖 Generated with [Claude Code](https://claude.com/claude-code)