### PR TITLE
Add SignalFileSaver to write completed.json and error.json per instance

### DIFF
--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -1,8 +1,8 @@
 from clemcore.clemgame.callbacks import episode_results_folder_callbacks
 from clemcore.clemgame.callbacks.base import GameBenchmarkCallback, GameBenchmarkCallbackList, GameStep
 from clemcore.clemgame.callbacks.files import ResultsFolder, InstanceFileSaver, ExperimentFileSaver, \
-    InteractionsFileSaver, RunFileSaver, EpochResultsFolder, EpisodeResultsFolder, EpochResultsFolderCallback, \
-    EpisodeResultsFolderCallback
+    InteractionsFileSaver, RunFileSaver, SignalFileSaver, EpochResultsFolder, EpisodeResultsFolder, \
+    EpochResultsFolderCallback, EpisodeResultsFolderCallback
 from clemcore.clemgame.envs.openenv.client import ClemGameEnv
 from clemcore.clemgame.envs.openenv.models import ClemGameObservation, ClemGameAction, ClemGameState
 from clemcore.clemgame.envs.pettingzoo import env, gym_env
@@ -42,6 +42,7 @@ __all__ = [
     "EpisodeResultsFolderCallback",
     "ResultsFolder",
     "RunFileSaver",
+    "SignalFileSaver",
     "InstanceFileSaver",
     "ExperimentFileSaver",
     "InteractionsFileSaver",

--- a/clemcore/clemgame/callbacks/base.py
+++ b/clemcore/clemgame/callbacks/base.py
@@ -25,7 +25,13 @@ class GameBenchmarkCallback(abc.ABC):
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
         pass
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+        """Called when a game episode ends, whether normally or due to an unexpected exception.
+
+        If exception is None, the episode completed normally. If exception is set, the episode
+        was aborted by an error. Implementors that only handle normal completion should guard
+        with ``if exception is not None: return`` at the top of their implementation.
+        """
         pass
 
     def on_benchmark_end(self, game_benchmark: "GameBenchmark"):
@@ -55,9 +61,9 @@ class GameBenchmarkCallbackList(GameBenchmarkCallback):
         for callback in self.callbacks:
             callback.on_game_step(game_master, game_instance, game_step)
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
         for callback in self.callbacks:
-            callback.on_game_end(game_master, game_instance)
+            callback.on_game_end(game_master, game_instance, exception)
 
     def on_benchmark_end(self, game_benchmark: "GameBenchmark"):
         for callback in self.callbacks:

--- a/clemcore/clemgame/callbacks/files.py
+++ b/clemcore/clemgame/callbacks/files.py
@@ -232,7 +232,9 @@ class InteractionsFileSaver(GameBenchmarkCallback):
         _key = InteractionsFileSaver.to_key(game_name, experiment_name, game_id)
         self._recorders[_key] = game_recorder
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+        if exception is not None:
+            return
         game_name = game_master.game_spec.game_name
         experiment_name = game_master.experiment["name"]
         game_id = game_instance["game_id"]
@@ -241,6 +243,38 @@ class InteractionsFileSaver(GameBenchmarkCallback):
         recorder = self._recorders.pop(_key)  # auto-remove recorder from registry
         instance_dir_path = self.results_folder.to_instance_dir_path(game_master, game_instance)
         store_json(recorder.interactions, "interactions.json", instance_dir_path)
+
+
+class SignalFileSaver(GameBenchmarkCallback):
+    """Writes a signal file into each instance directory to indicate run outcome.
+
+    - ``completed.json`` — written when a game episode finishes without error.
+    - ``error.json``     — written when an exception aborts the episode.
+
+    These files make it easy to check the run status of any instance at a glance,
+    and support future ``--resume`` logic (see issue #231).
+    """
+
+    def __init__(self, results_folder: ResultsFolder):
+        self.results_folder = results_folder
+
+    def on_game_start(self, game_master: "GameMaster", game_instance: Dict):
+        instance_dir_path = self.results_folder.to_instance_dir_path(game_master, game_instance)
+        for signal_file in ["completed.json", "error.json"]:
+            signal_path = instance_dir_path / signal_file
+            if signal_path.exists():
+                signal_path.unlink()
+
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+        instance_dir_path = self.results_folder.to_instance_dir_path(game_master, game_instance)
+        if exception is None:
+            store_json({"timestamp": datetime.now().isoformat()}, "completed.json", instance_dir_path)
+        else:
+            store_json({
+                "timestamp": datetime.now().isoformat(),
+                "error": type(exception).__name__,
+                "message": str(exception)
+            }, "error.json", instance_dir_path)
 
 
 class PlayerFileSaver(GameBenchmarkCallback):
@@ -271,7 +305,9 @@ class PlayerFileSaver(GameBenchmarkCallback):
             _key = PlayerFileSaver.to_key(game_name, experiment_name, game_id, player.name)
             self._recorders[_key] = recorder
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+        if exception is not None:
+            return
         game_name = game_master.game_spec.game_name
         experiment_name = game_master.experiment["name"]
         game_id = game_instance["game_id"]

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Callable
 
 import gymnasium
@@ -125,6 +126,28 @@ def env(game_name: str,
     return game_env
 
 
+def _notify_on_error(method):
+    """Decorator for GameMasterEnv methods that notifies callbacks when a game episode ends
+    unexpectedly due to an exception, then reraises.
+
+    This ensures callbacks such as SignalFileSaver can write signal files (e.g. error.json)
+    regardless of whether the episode ended normally or due to an error, mirroring the
+    on_game_end call that happens in step() on normal completion.
+
+    Only notifies when game_master is already initialised (i.e. after create_game_master()
+    succeeded in reset()), so callbacks always receive a valid game_master instance.
+    """
+    @wraps(method)
+    def wrapper(self: "GameMasterEnv", *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except Exception as e:
+            if self.game_master is not None and self.game_instance is not None:
+                self.callbacks.on_game_end(self.game_master, self.game_instance, e)
+            raise
+    return wrapper
+
+
 class GameMasterEnv(AECEnv):
 
     def __init__(self, game_benchmark: GameBenchmark, *, callbacks: GameBenchmarkCallbackList | None = None,
@@ -179,6 +202,7 @@ class GameMasterEnv(AECEnv):
         """ Mapping the current player to an agent id """
         return self.player_to_agent_id[self.game_master.current_player.name]
 
+    @_notify_on_error
     def reset(self, seed: int | None = None, options: dict | None = None):
         self.options = options or {}
         assert "experiment" in self.options, "Missing 'experiment' in reset options"
@@ -213,6 +237,7 @@ class GameMasterEnv(AECEnv):
             self._cumulative_rewards[agent] = 0.
             self.infos[agent] = {}
 
+    @_notify_on_error
     def step(self, action: ActionType) -> None:
         """Accepts, executes, and logs the action of the current agent in the environment.
 

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -13,7 +13,7 @@ from clemcore.clemgame import GameRegistry, GameSpec, InstanceFileSaver, Experim
     InteractionsFileSaver, GameBenchmarkCallbackList, RunFileSaver, GameInstances, ResultsFolder, \
     GameBenchmark
 from clemcore import clemeval, get_version, load_logging_config
-from clemcore.clemgame.callbacks.files import PlayerFileSaver
+from clemcore.clemgame.callbacks.files import PlayerFileSaver, SignalFileSaver
 from clemcore.clemgame.runners import dispatch
 from clemcore.clemgame.transcripts.builder import build_transcripts
 from clemcore.utils.string_utils import read_query_string
@@ -177,7 +177,8 @@ def run(game_selectors: Union[str, Dict, GameSpec, List[Union[str, Dict, GameSpe
         ExperimentFileSaver(results_folder, player_model_infos=model_infos),
         InteractionsFileSaver(results_folder, player_model_infos=model_infos),
         RunFileSaver(results_folder, player_model_infos=model_infos),
-        PlayerFileSaver(results_folder)
+        PlayerFileSaver(results_folder),
+        SignalFileSaver(results_folder)
     ])
 
     all_start = datetime.now()


### PR DESCRIPTION
Closes #233.

## Summary

Adds a `SignalFileSaver` callback that writes a small signal file into each instance directory after every game episode, making the run status immediately visible from the file system.

## Signal file semantics

| State | Signal file |
|-------|-------------|
| Not started, or interrupted mid-run (e.g. ctrl+c) | *(no file)* |
| Finished successfully | `completed.json` |
| Finished with an exception | `error.json` |

This three-state scheme naturally supports future `--resume` logic (issue #231): skip instances that have `completed.json`, rerun everything else — interrupted runs are automatically retried alongside never-started ones.

On repeated runs over the same folder structure, stale signal files are cleaned up in `on_game_start` before the new run begins.

## Design

- `on_game_end` extended with an optional `exception` argument (following pytest's unified outcome approach): `exception=None` means normal completion, set means the episode was aborted by an error
- `_notify_on_error` decorator on `GameMasterEnv.reset()` and `step()` fires `on_game_end` with the exception and reraises, keeping error signalling consistent with where other lifecycle callbacks are triggered
- `InteractionsFileSaver` and `PlayerFileSaver` guard against the error case to avoid writing partial data

🤖 Generated with [Claude Code](https://claude.com/claude-code)