### PR TITLE
Add -m/--model to clem eval for incremental model updates

### DIFF
--- a/clemcore/clemeval.py
+++ b/clemcore/clemeval.py
@@ -134,10 +134,16 @@ def parse_directory_name(name: Path) -> dict:
             'episode': episode}
 
 
-def load_scores(path: str) -> dict:
-    """Get all turn and episodes scores and return them in a dictionary."""
+def load_scores(path: str, model_selector: str = None) -> dict:
+    """Get all turn and episodes scores and return them in a dictionary.
+    Args:
+        path: Root directory to search for score files.
+        model_selector: Optional substring to filter score files by model name.
+    """
     # https://stackoverflow.com/a/18394205
     score_files = list(Path(path).rglob("*scores.json"))
+    if model_selector is not None:
+        score_files = [f for f in score_files if model_selector in str(f)]
     print(f'Loading {len(score_files)} JSON files.')
     scores = {}
     for path in tqdm(score_files, desc="Loading scores"):
@@ -167,22 +173,50 @@ def build_df_episode_scores(scores: dict) -> pd.DataFrame:
 
 
 def perform_evaluation(results_path: str, return_dataframe: bool = False,
-                       show_std: bool = False, sort_by: str = "model_name") -> pd.DataFrame | None:
-    # Get all episode scores as a pandas dataframe
-    scores = load_scores(path=results_path)
-    df_episode_scores = build_df_episode_scores(scores)
+                       show_std: bool = False, sort_by: str = "model_name",
+                       model_selector: str = None) -> pd.DataFrame | None:
+    """Run evaluation and save results table.
+    Args:
+        results_path: Root directory containing score files and where results are saved.
+        return_dataframe: If True, return the results dataframe.
+        show_std: If True, include standard deviation columns.
+        sort_by: Sort rows by 'model_name' or 'clemscore'.
+        model_selector: Optional substring to restrict evaluation to a single model.
+            When set, loads only that model's scores from disk, merges them into the
+            existing raw.csv (replacing any previous rows for that model), and
+            recomputes the full results table. This allows incremental updates without
+            re-scoring all models.
+    """
+    raw_csv_path = Path(results_path) / 'raw.csv'
 
-    # Create the PLAYED variable, inferring it from ABORTED
-    if clemmetrics.METRIC_PLAYED in df_episode_scores['metric'].unique():
-        raise PlayedScoreError("Computed scores should not contain METRIC_PLAYED.")
-    aux = df_episode_scores[df_episode_scores["metric"] == clemmetrics.METRIC_ABORTED].copy()
-    aux["metric"] = clemmetrics.METRIC_PLAYED
-    aux["value"] = 1 - aux["value"]
-    # We need ignore_index=True to reset the indices (otherwise we have duplicates)
-    df_episode_scores = pd.concat([df_episode_scores, aux], ignore_index=True)
+    if model_selector is not None and raw_csv_path.exists():
+        # Incremental update: load existing raw data, drop old rows for this model,
+        # load fresh scores for the selected model, then recompute the full table.
+        df_existing = pd.read_csv(raw_csv_path, index_col=0)
+        df_existing = df_existing[~df_existing['model'].str.contains(model_selector, na=False)]
+        scores = load_scores(path=results_path, model_selector=model_selector)
+        df_new = build_df_episode_scores(scores)
+        # Add PLAYED for the new rows
+        if clemmetrics.METRIC_PLAYED in df_new['metric'].unique():
+            raise PlayedScoreError("Computed scores should not contain METRIC_PLAYED.")
+        aux = df_new[df_new["metric"] == clemmetrics.METRIC_ABORTED].copy()
+        aux["metric"] = clemmetrics.METRIC_PLAYED
+        aux["value"] = 1 - aux["value"]
+        df_new = pd.concat([df_new, aux], ignore_index=True)
+        df_episode_scores = pd.concat([df_existing, df_new], ignore_index=True)
+    else:
+        # Full evaluation: load all scores from disk.
+        scores = load_scores(path=results_path, model_selector=model_selector)
+        df_episode_scores = build_df_episode_scores(scores)
+        if clemmetrics.METRIC_PLAYED in df_episode_scores['metric'].unique():
+            raise PlayedScoreError("Computed scores should not contain METRIC_PLAYED.")
+        aux = df_episode_scores[df_episode_scores["metric"] == clemmetrics.METRIC_ABORTED].copy()
+        aux["metric"] = clemmetrics.METRIC_PLAYED
+        aux["value"] = 1 - aux["value"]
+        df_episode_scores = pd.concat([df_episode_scores, aux], ignore_index=True)
 
     # save raw scores
-    df_episode_scores.to_csv(Path(results_path) / f'raw.csv')
+    df_episode_scores.to_csv(raw_csv_path)
     print(f'\n Saved raw scores into {results_path}/raw.csv')
 
     # save main table

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -352,7 +352,7 @@ def cli(args: argparse.Namespace):
     if args.command_name == "transcribe":
         transcripts(args.game, results_dir=args.results_dir)
     if args.command_name == "eval":
-        clemeval.perform_evaluation(args.results_dir, show_std=args.std, sort_by=args.sort)
+        clemeval.perform_evaluation(args.results_dir, show_std=args.std, sort_by=args.sort, model_selector=args.model)
 
 
 def main():
@@ -477,6 +477,10 @@ Update Behavior:
                              help="Include standard deviation columns in the results table. Default: off.")
     eval_parser.add_argument("--sort", type=str, choices=["model_name", "clemscore"], default="model_name",
                              help="Sort results by model name or clemscore. Default: model_name.")
+    eval_parser.add_argument("-m", "--model", type=str, default=None,
+                             help="A model name substring to add or re-evaluate a single model. "
+                                  "If given, loads only that model's scores from disk, sets them into "
+                                  "the existing raw.csv, and recomputes the full results table.")
 
     serve_parser = sub_parsers.add_parser("serve")
     serve_parser.add_argument("-g", "--game",

--- a/tests/test_clemeval.py
+++ b/tests/test_clemeval.py
@@ -133,7 +133,7 @@ class TestPerformEvaluation(unittest.TestCase):
                 {'game': 'taboo', 'model': 'gpt-4', 'experiment': 'exp1', 'episode': 'ep1',
                  'metric': clemmetrics.METRIC_PLAYED, 'value': 1},
             ])
-            clemeval.load_scores = lambda path: {}
+            clemeval.load_scores = lambda path, model_selector=None: {}
             clemeval.build_df_episode_scores = lambda scores: bad_df
 
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -151,7 +151,7 @@ class TestPerformEvaluation(unittest.TestCase):
         original_build = clemeval.build_df_episode_scores
 
         try:
-            clemeval.load_scores = lambda path: {}
+            clemeval.load_scores = lambda path, model_selector=None: {}
             clemeval.build_df_episode_scores = lambda scores: _minimal_scores()
 
             with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds `-m/--model` option to `clem eval`, matching the substring-based filtering already in `clem score -m`
- When `-m <model>` is given: loads only that model's scores from disk, drops existing rows for that model from `raw.csv`, merges in the fresh rows, and recomputes the full results table (including sort and std options)
- When no `-m` is given: full evaluation as before — all models from disk

## Incremental update behaviour

`raw.csv` is the source of truth. The update strategy is:

1. Load existing `raw.csv`
2. Drop rows where `model` column contains `model_selector` (substring match)
3. Load new scores for the selected model from disk
4. Concat old + new, recompute `results.csv` and `results.html`

This allows adding a single newly-scored model to an existing results table without re-scoring everything.

## Test plan

- [x] Existing `test_clemeval.py` and `test_cli.py` tests pass (21 tests)
- [x] Lambda stubs in tests updated to accept `model_selector=None` kwarg

🤖 Generated with [Claude Code](https://claude.com/claude-code)