### PR TITLE
Add -g/--game to clem eval for incremental game updates

### DIFF
--- a/clemcore/clemeval.py
+++ b/clemcore/clemeval.py
@@ -134,16 +134,19 @@ def parse_directory_name(name: Path) -> dict:
             'episode': episode}
 
 
-def load_scores(path: str, model_selector: str = None) -> dict:
+def load_scores(path: str, model_selector: str = None, game_selector: str = None) -> dict:
     """Get all turn and episodes scores and return them in a dictionary.
     Args:
         path: Root directory to search for score files.
         model_selector: Optional substring to filter score files by model name.
+        game_selector: Optional substring to filter score files by game name.
     """
     # https://stackoverflow.com/a/18394205
     score_files = list(Path(path).rglob("*scores.json"))
     if model_selector is not None:
         score_files = [f for f in score_files if model_selector in str(f)]
+    if game_selector is not None:
+        score_files = [f for f in score_files if game_selector in Path(f).parts]
     print(f'Loading {len(score_files)} JSON files.')
     scores = {}
     for path in tqdm(score_files, desc="Loading scores"):
@@ -174,29 +177,35 @@ def build_df_episode_scores(scores: dict) -> pd.DataFrame:
 
 def perform_evaluation(results_path: str, return_dataframe: bool = False,
                        show_std: bool = False, sort_by: str = "model_name",
-                       model_selector: str = None) -> pd.DataFrame | None:
+                       model_selector: str = None, game_selector: str = None) -> pd.DataFrame | None:
     """Run evaluation and save results table.
     Args:
         results_path: Root directory containing score files and where results are saved.
         return_dataframe: If True, return the results dataframe.
         show_std: If True, include standard deviation columns.
         sort_by: Sort rows by 'model_name' or 'clemscore'.
-        model_selector: Optional substring to restrict evaluation to a single model.
-            When set, loads only that model's scores from disk, merges them into the
-            existing raw.csv (replacing any previous rows for that model), and
-            recomputes the full results table. This allows incremental updates without
-            re-scoring all models.
+        model_selector: Optional substring to restrict evaluation to a specific model.
+            When set (with or without game_selector), loads only matching scores from
+            disk, merges them into the existing raw.csv (replacing matching rows), and
+            recomputes the full results table.
+        game_selector: Optional substring to restrict evaluation to a specific game.
+            Can be combined with model_selector for finer-grained updates.
     """
     raw_csv_path = Path(results_path) / 'raw.csv'
+    incremental = (model_selector is not None or game_selector is not None) and raw_csv_path.exists()
 
-    if model_selector is not None and raw_csv_path.exists():
-        # Incremental update: load existing raw data, drop old rows for this model,
-        # load fresh scores for the selected model, then recompute the full table.
+    if incremental:
+        # Incremental update: load existing raw data, drop rows matching the selectors,
+        # load fresh scores for the selection, then recompute the full table.
         df_existing = pd.read_csv(raw_csv_path, index_col=0)
-        df_existing = df_existing[~df_existing['model'].str.contains(model_selector, na=False)]
-        scores = load_scores(path=results_path, model_selector=model_selector)
+        mask = pd.Series(True, index=df_existing.index)
+        if model_selector is not None:
+            mask &= df_existing['model'].str.contains(model_selector, na=False)
+        if game_selector is not None:
+            mask &= df_existing['game'] == game_selector
+        df_existing = df_existing[~mask]
+        scores = load_scores(path=results_path, model_selector=model_selector, game_selector=game_selector)
         df_new = build_df_episode_scores(scores)
-        # Add PLAYED for the new rows
         if clemmetrics.METRIC_PLAYED in df_new['metric'].unique():
             raise PlayedScoreError("Computed scores should not contain METRIC_PLAYED.")
         aux = df_new[df_new["metric"] == clemmetrics.METRIC_ABORTED].copy()
@@ -206,7 +215,7 @@ def perform_evaluation(results_path: str, return_dataframe: bool = False,
         df_episode_scores = pd.concat([df_existing, df_new], ignore_index=True)
     else:
         # Full evaluation: load all scores from disk.
-        scores = load_scores(path=results_path, model_selector=model_selector)
+        scores = load_scores(path=results_path, model_selector=model_selector, game_selector=game_selector)
         df_episode_scores = build_df_episode_scores(scores)
         if clemmetrics.METRIC_PLAYED in df_episode_scores['metric'].unique():
             raise PlayedScoreError("Computed scores should not contain METRIC_PLAYED.")

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -352,7 +352,13 @@ def cli(args: argparse.Namespace):
     if args.command_name == "transcribe":
         transcripts(args.game, results_dir=args.results_dir)
     if args.command_name == "eval":
-        clemeval.perform_evaluation(args.results_dir, show_std=args.std, sort_by=args.sort, model_selector=args.model)
+        clemeval.perform_evaluation(
+            args.results_dir,
+            show_std=args.std,
+            sort_by=args.sort,
+            model_selector=args.model,
+            game_selector=args.game
+        )
 
 
 def main():
@@ -480,7 +486,11 @@ Update Behavior:
     eval_parser.add_argument("-m", "--model", type=str, default=None,
                              help="A model name substring to add or re-evaluate a single model. "
                                   "If given, loads only that model's scores from disk, sets them into "
-                                  "the existing raw.csv, and recomputes the full results table.")
+                                  "the existing raw.csv, and recomputes the full results table."
+                                  "Can be combined with -g to update a specific model/game combination.")
+    eval_parser.add_argument("-g", "--game", type=str, default=None,
+                             help="A game name substring to add or re-evaluate a single game. "
+                                  "Can be combined with -m to update a specific model/game combination.")
 
     serve_parser = sub_parsers.add_parser("serve")
     serve_parser.add_argument("-g", "--game",

--- a/tests/test_clemeval.py
+++ b/tests/test_clemeval.py
@@ -133,7 +133,7 @@ class TestPerformEvaluation(unittest.TestCase):
                 {'game': 'taboo', 'model': 'gpt-4', 'experiment': 'exp1', 'episode': 'ep1',
                  'metric': clemmetrics.METRIC_PLAYED, 'value': 1},
             ])
-            clemeval.load_scores = lambda path, model_selector=None: {}
+            clemeval.load_scores = lambda path, model_selector=None, game_selector=None: {}
             clemeval.build_df_episode_scores = lambda scores: bad_df
 
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -151,7 +151,7 @@ class TestPerformEvaluation(unittest.TestCase):
         original_build = clemeval.build_df_episode_scores
 
         try:
-            clemeval.load_scores = lambda path, model_selector=None: {}
+            clemeval.load_scores = lambda path, model_selector=None, game_selector=None: {}
             clemeval.build_df_episode_scores = lambda scores: _minimal_scores()
 
             with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds `-g/--game` option to `clem eval`, complementing the existing `-m/--model` selector
- Game matching uses `game_selector in Path(f).parts` — exact path component membership, robust to any directory depth (unlike substring matching which can false-match model names containing game names)
- Both `-m` and `-g` can be combined to update a specific model/game combination
- Missing values (models that did not play the selected game) appear as `NaN` in the output table, consistent with full eval behaviour

Partially addresses #234 — games can now be added or re-evaluated individually without rerunning the full eval.

## Incremental update behaviour

For `-g taboo`:
1. Load existing `raw.csv`
2. Drop rows where `game == "taboo"` (exact match)
3. Load score files where `"taboo" in Path(f).parts` (exact path component)
4. Concat old + new, recompute `results.csv` and `results.html`

For `-m gpt-4 -g taboo`: drops rows matching both conditions (AND logic).

## Test plan

- [x] Existing `test_clemeval.py` and `test_cli.py` tests pass (21 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)