### PR TITLE
Introduce BranchingRunner, GameSnapshot and add more meta-info to GameState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 # Ours
 key*.json
 model_registry*.json
+game_registry*.json
 *results*
 openenv-records*/
 /venv
 evaltmp.ipynb
 .run
 CLAUDE.md
+.aider*
 
 # Wordlists https://www.kaggle.com/datasets/rtatman/english-word-frequency
 unigram_freq.csv

--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -1,5 +1,5 @@
 from clemcore.clemgame.callbacks import episode_results_folder_callbacks
-from clemcore.clemgame.callbacks.base import GameBenchmarkCallback, GameBenchmarkCallbackList, GameStep
+from clemcore.clemgame.callbacks.base import GameBenchmarkCallback, GameBenchmarkCallbackList, GameStep, GameSnapshot
 from clemcore.clemgame.callbacks.files import ResultsFolder, InstanceFileSaver, ExperimentFileSaver, \
     InteractionsFileSaver, RunFileSaver, SignalFileSaver, EpochResultsFolder, EpisodeResultsFolder, \
     EpochResultsFolderCallback, EpisodeResultsFolderCallback
@@ -10,7 +10,7 @@ from clemcore.clemgame.errors import GameError, ParseError, RuleViolationError, 
     NotApplicableError
 from clemcore.clemgame.instances import GameInstanceGenerator, GameInstances
 from clemcore.clemgame.resources import GameResourceLocator
-from clemcore.clemgame.master import GameMaster, DialogueGameMaster, Player
+from clemcore.clemgame.master import GameMaster, DialogueGameMaster, Player, GameState
 from clemcore.clemgame.metrics import GameScorer
 from clemcore.clemgame.recorder import GameInteractionsRecorder
 from clemcore.clemgame.registry import GameSpec, GameRegistry
@@ -21,7 +21,9 @@ __all__ = [
     "GameBenchmarkCallback",
     "GameBenchmarkCallbackList",
     "GameStep",
+    "GameSnapshot",
     "Player",
+    "GameState",
     "GameMaster",
     "DialogueGameMaster",
     "ClemGameEnv",

--- a/clemcore/clemgame/callbacks/base.py
+++ b/clemcore/clemgame/callbacks/base.py
@@ -12,6 +12,8 @@ class GameStep:
     response: str
     done: bool = False
     info: dict = field(default_factory=dict)
+    player_name: str | None = None
+    model_name: str | None = None
 
 
 class GameBenchmarkCallback(abc.ABC):
@@ -20,6 +22,9 @@ class GameBenchmarkCallback(abc.ABC):
         pass
 
     def on_game_start(self, game_master: "GameMaster", game_instance: Dict):
+        pass
+
+    def on_branch_start(self, game_master: "GameMaster", game_instance: Dict, parent_id: str):
         pass
 
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
@@ -56,6 +61,10 @@ class GameBenchmarkCallbackList(GameBenchmarkCallback):
     def on_game_start(self, game_master: "GameMaster", game_instance: Dict):
         for callback in self.callbacks:
             callback.on_game_start(game_master, game_instance)
+
+    def on_branch_start(self, game_master: "GameMaster", game_instance: Dict, parent_id: str):
+        for callback in self.callbacks:
+            callback.on_branch_start(game_master, game_instance, parent_id)
 
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
         for callback in self.callbacks:

--- a/clemcore/clemgame/callbacks/base.py
+++ b/clemcore/clemgame/callbacks/base.py
@@ -30,7 +30,8 @@ class GameBenchmarkCallback(abc.ABC):
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
         pass
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict,
+                    exception: Exception = None, rewards: dict[str, float] = None):
         """Called when a game episode ends, whether normally or due to an unexpected exception.
 
         If exception is None, the episode completed normally. If exception is set, the episode
@@ -70,9 +71,10 @@ class GameBenchmarkCallbackList(GameBenchmarkCallback):
         for callback in self.callbacks:
             callback.on_game_step(game_master, game_instance, game_step)
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict,
+                    exception: Exception = None, rewards: dict[str, float] = None):
         for callback in self.callbacks:
-            callback.on_game_end(game_master, game_instance, exception)
+            callback.on_game_end(game_master, game_instance, exception, rewards)
 
     def on_benchmark_end(self, game_benchmark: "GameBenchmark"):
         for callback in self.callbacks:

--- a/clemcore/clemgame/callbacks/base.py
+++ b/clemcore/clemgame/callbacks/base.py
@@ -24,7 +24,7 @@ class GameBenchmarkCallback(abc.ABC):
     def on_game_start(self, game_master: "GameMaster", game_instance: Dict):
         pass
 
-    def on_branch_start(self, game_master: "GameMaster", game_instance: Dict, parent_id: str):
+    def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, branching_point_id: str):
         pass
 
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
@@ -63,9 +63,9 @@ class GameBenchmarkCallbackList(GameBenchmarkCallback):
         for callback in self.callbacks:
             callback.on_game_start(game_master, game_instance)
 
-    def on_branch_start(self, game_master: "GameMaster", game_instance: Dict, parent_id: str):
+    def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, branching_point_id: str):
         for callback in self.callbacks:
-            callback.on_branch_start(game_master, game_instance, parent_id)
+            callback.on_branching_point(game_master, game_instance, branching_point_id)
 
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
         for callback in self.callbacks:

--- a/clemcore/clemgame/callbacks/base.py
+++ b/clemcore/clemgame/callbacks/base.py
@@ -1,9 +1,11 @@
 import abc
+from copy import deepcopy
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import List, TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:  # to satisfy pycharm
-    from clemcore.clemgame import GameMaster, GameBenchmark
+    from clemcore.clemgame import GameMaster, GameBenchmark, GameState
 
 
 @dataclass
@@ -16,6 +18,20 @@ class GameStep:
     model_name: str | None = None
 
 
+@dataclass(frozen=True)
+class GameSnapshot:
+    origin: int
+    state: "GameState" = field(compare=False)
+    timestamp: datetime = field(default_factory=datetime.now, compare=False)
+
+    def __str__(self):
+        return f"{self.origin}@{self.timestamp.strftime('%Y%m%d-%H%M%S-%f')}"
+
+    @classmethod
+    def create_from(cls, game_master: "GameMaster") -> "GameSnapshot":
+        return cls(origin=id(game_master), state=deepcopy(game_master.state))
+
+
 class GameBenchmarkCallback(abc.ABC):
 
     def on_benchmark_start(self, game_benchmark: "GameBenchmark"):
@@ -24,7 +40,7 @@ class GameBenchmarkCallback(abc.ABC):
     def on_game_start(self, game_master: "GameMaster", game_instance: Dict):
         pass
 
-    def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, branching_point_id: str):
+    def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, snapshot: GameSnapshot):
         pass
 
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
@@ -63,9 +79,9 @@ class GameBenchmarkCallbackList(GameBenchmarkCallback):
         for callback in self.callbacks:
             callback.on_game_start(game_master, game_instance)
 
-    def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, branching_point_id: str):
+    def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, snapshot: GameSnapshot):
         for callback in self.callbacks:
-            callback.on_branching_point(game_master, game_instance, branching_point_id)
+            callback.on_branching_point(game_master, game_instance, snapshot)
 
     def on_game_step(self, game_master: "GameMaster", game_instance: Dict, game_step: GameStep):
         for callback in self.callbacks:

--- a/clemcore/clemgame/callbacks/files.py
+++ b/clemcore/clemgame/callbacks/files.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, TYPE_CHECKING, Any
+from threading import Lock
 
 from clemcore import get_version
 
@@ -204,11 +205,30 @@ class ExperimentFileSaver(GameBenchmarkCallback):
         store_json(experiment_config, "experiment.json", experiment_dir_path)
 
 
+class BranchCounter:
+
+    def __init__(self):
+        self._counters: Dict[str, int] = {}
+        self._lock = Lock()
+
+    def __deepcopy__(self, memo):
+        # Always return the same instance - this must be shared across all branches
+        return self
+
+    def next(self, key: str) -> int:
+        with self._lock:
+            count = self._counters.get(key, 0)
+            self._counters[key] = count + 1
+            return count
+
+
 class InteractionsFileSaver(GameBenchmarkCallback):
 
-    def __init__(self, results_folder: ResultsFolder, *, player_model_infos: Any = None):
+    def __init__(self, results_folder: ResultsFolder, *, player_model_infos: Any = None, store_branches: bool = False):
         self.results_folder = results_folder
         self.player_models_infos = player_model_infos
+        self._store_branches = store_branches
+        self._branch_counter = BranchCounter()
         self._recorders: Dict[str, GameInteractionsRecorder] = {}
 
     @staticmethod
@@ -242,6 +262,8 @@ class InteractionsFileSaver(GameBenchmarkCallback):
         assert _key in self._recorders, f"Recorder must be registered on_game_start, but wasn't for: {_key}"
         recorder = self._recorders.pop(_key)  # auto-remove recorder from registry
         instance_dir_path = self.results_folder.to_instance_dir_path(game_master, game_instance)
+        if self._store_branches:
+            instance_dir_path = instance_dir_path / f"branch_{self._branch_counter.next(_key) + 1:05d}"
         store_json(recorder.interactions, "interactions.json", instance_dir_path)
 
 

--- a/clemcore/clemgame/callbacks/files.py
+++ b/clemcore/clemgame/callbacks/files.py
@@ -252,7 +252,8 @@ class InteractionsFileSaver(GameBenchmarkCallback):
         _key = InteractionsFileSaver.to_key(game_name, experiment_name, game_id)
         self._recorders[_key] = game_recorder
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict,
+                    exception: Exception = None, rewards: dict[str, float] = None):
         if exception is not None:
             return
         game_name = game_master.game_spec.game_name
@@ -287,7 +288,8 @@ class SignalFileSaver(GameBenchmarkCallback):
             if signal_path.exists():
                 signal_path.unlink()
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict,
+                    exception: Exception = None, rewards: dict[str, float] = None):
         instance_dir_path = self.results_folder.to_instance_dir_path(game_master, game_instance)
         if exception is None:
             store_json({"timestamp": datetime.now().isoformat()}, "completed.json", instance_dir_path)
@@ -327,7 +329,8 @@ class PlayerFileSaver(GameBenchmarkCallback):
             _key = PlayerFileSaver.to_key(game_name, experiment_name, game_id, player.name)
             self._recorders[_key] = recorder
 
-    def on_game_end(self, game_master: "GameMaster", game_instance: Dict, exception: Exception = None):
+    def on_game_end(self, game_master: "GameMaster", game_instance: Dict,
+                    exception: Exception = None, rewards: dict[str, float] = None):
         if exception is not None:
             return
         game_name = game_master.game_spec.game_name

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -66,7 +66,8 @@ def gym_env(game_name: str,
     Returns:
         A fully initialized game env ready for RL-like training
     """
-    game_env = env(game_name, instances_filter=instances_filter, single_pass=single_pass, callbacks=callbacks, reward_func=reward_func, feedback_func=feedback_func)
+    game_env = env(game_name, instances_filter=instances_filter, single_pass=single_pass, callbacks=callbacks,
+                   reward_func=reward_func, feedback_func=feedback_func)
     game_env = SinglePlayerWrapper(game_env, learner_agent, env_agents=env_agents)
     game_env = AECToGymWrapper(game_env)
     return game_env
@@ -114,7 +115,8 @@ def env(game_name: str,
     # Load game registry
     game_registry = GameRegistry.from_directories_and_cwd_files()
     game_spec = game_registry.get_game_specs_that_unify_with(game_name)[0]
-    game_env = GameBenchmarkWrapper(GameMasterEnv, game_spec=game_spec, callbacks=callbacks, reward_func=reward_func, feedback_func=feedback_func)
+    game_env = GameBenchmarkWrapper(GameMasterEnv, game_spec=game_spec, callbacks=callbacks, reward_func=reward_func,
+                                    feedback_func=feedback_func)
 
     # Warn env users in case of wrong method execution order
     game_env = OrderEnforcingWrapper(game_env)
@@ -137,6 +139,7 @@ def _notify_on_error(method):
     Only notifies when game_master is already initialised (i.e. after create_game_master()
     succeeded in reset()), so callbacks always receive a valid game_master instance.
     """
+
     @wraps(method)
     def wrapper(self: "GameMasterEnv", *args, **kwargs):
         try:
@@ -145,6 +148,7 @@ def _notify_on_error(method):
             if self.game_master is not None and self.game_instance is not None:
                 self.callbacks.on_game_end(self.game_master, self.game_instance, e)
             raise
+
     return wrapper
 
 
@@ -255,6 +259,10 @@ class GameMasterEnv(AECEnv):
             # Note: This removes the agent and selects the next (dead) agent in self.agents
             # or selects the next live agent stored during _deads_step_first() at the end of this step
             self._was_dead_step(action)
+            if not self.agents:
+                # PZ doesn't handle this case: All agents terminate simultaneously.
+                # See https://github.com/Farama-Foundation/PettingZoo/issues/652
+                self.agent_selection = None
             return
 
         # After step() current_player might have changed, so we reference it here already

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -295,7 +295,7 @@ class GameMasterEnv(AECEnv):
                 # Note: we do not handle truncations separately yet, e.g., running out of turns
                 self.terminations[agent_id] = True
                 self.rewards[agent_id] = self._reward_func(current_context, action, self.game_master.state, info)
-            self.callbacks.on_game_end(self.game_master, self.game_instance)
+            self.callbacks.on_game_end(self.game_master, self.game_instance, rewards=self.rewards)
 
         # Collect and reset the rewards for all agents
         # Note: We accumulate the rewards to collect all environmental impacts on an agent until its next call of last()

--- a/clemcore/clemgame/envs/pettingzoo/master.py
+++ b/clemcore/clemgame/envs/pettingzoo/master.py
@@ -267,9 +267,10 @@ class GameMasterEnv(AECEnv):
 
         # After step() current_player might have changed, so we reference it here already
         current_agent = self.get_current_agent()
+        current_player = self.player_by_agent_id[current_agent]
 
         # Get the context that was given from GM -> Player (logging happens in game_master.step)
-        current_context = self.game_master.get_context_for(self.player_by_agent_id[current_agent])
+        current_context = self.game_master.get_context_for(current_player)
 
         # Step possibly transitions the current agent (as specified by the game master)
         # Log the response action from Player -> GM
@@ -283,7 +284,7 @@ class GameMasterEnv(AECEnv):
         self.infos[current_agent] = info
 
         # Inform callbacks about the game step results
-        game_step = GameStep(current_context, action, done, info)
+        game_step = GameStep(current_context, action, done, info, current_player.name, current_player.model.name)
         self.callbacks.on_game_step(self.game_master, self.game_instance, game_step)
 
         # The terminal case:

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -108,6 +108,7 @@ class DialogueGameMaster(GameMaster):
     def before_game(self):
         self._on_before_game()
         self.current_round += 1
+        self.state.current_turn += 1
         self._on_before_round()
 
     @abc.abstractmethod
@@ -220,6 +221,9 @@ class DialogueGameMaster(GameMaster):
             self.log_game_end(auto_count_logging=False)
         elif self._start_next_round():  # prepare next round only when game has not ended yet
             self.__prepare_next_round()
+
+        if not done:
+            self.state.current_turn += 1
 
         info = deepcopy(self.info)
         self.info = {}  # reset info after each step

--- a/clemcore/clemgame/legacy/master.py
+++ b/clemcore/clemgame/legacy/master.py
@@ -104,11 +104,12 @@ class DialogueGameMaster(GameMaster):
         """
         self._on_setup(**kwargs)
         self._current_player = self.get_players()[self._current_player_idx]
+        self.state.game_id = kwargs.get("game_id", None)
 
     def before_game(self):
         self._on_before_game()
         self.current_round += 1
-        self.state.current_turn += 1
+        self.state.current_turn = 0
         self._on_before_round()
 
     @abc.abstractmethod

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -31,6 +31,7 @@ class GameState:
 
     def __init__(self):
         self.outcome = Outcome.RUNNING
+        self.current_turn = -1
 
     def succeed(self):
         self.outcome = Outcome.SUCCESS
@@ -284,6 +285,7 @@ class DialogueGameMaster(GameMaster):
     def before_game(self):
         self._on_before_game()
         self.current_round += 1
+        self.state.current_turn += 1
         self._on_before_round()
 
     @abc.abstractmethod
@@ -389,7 +391,6 @@ class DialogueGameMaster(GameMaster):
         except GameError as error:
             self._on_game_error(error)
 
-
         # determine if the current player should pass the turn to the next player or get another turn:
         if self._should_pass_turn():  # True = move on to next player
             self._current_player = self._next_player()
@@ -399,11 +400,15 @@ class DialogueGameMaster(GameMaster):
             self.current_round += 1  # already increment here b.c. _does_game_proceed might rely on it
 
         done = not self._does_game_proceed()
+
         if done:
             self._on_after_game()
             self.log_game_end()
         elif self._start_next_round():  # prepare next round only when game has not ended yet
             self.__prepare_next_round()
+
+        if not done:
+            self.state.current_turn += 1
 
         info = deepcopy(self.info)
         self.info = {}  # reset info after each step

--- a/clemcore/clemgame/master.py
+++ b/clemcore/clemgame/master.py
@@ -31,7 +31,14 @@ class GameState:
 
     def __init__(self):
         self.outcome = Outcome.RUNNING
-        self.current_turn = -1
+        self.current_turn: int | None = None
+        self.game_id: int | None = None
+        self.game_name: str | None = None
+        self.experiment_name: str | None = None
+
+    def __str__(self):
+        # Example: [Experiment] GameName (ID) | Turn: 5
+        return f"[{self.experiment_name[:10]}] {self.game_name} ({self.game_id}) | Turn: {self.current_turn:02d}"
 
     def succeed(self):
         self.outcome = Outcome.SUCCESS
@@ -61,6 +68,8 @@ class GameMaster(GameEventSource):
         """
         super().__init__()
         self.state = state or GameState()
+        self.state.game_name = game_spec.game_name
+        self.state.experiment_name = experiment.get("name", None)
         self.game_spec = game_spec
         self.experiment = experiment
         # Automatic player expansion: When only a single model is given, then use this model given for each game role.
@@ -280,12 +289,13 @@ class DialogueGameMaster(GameMaster):
         """
         self._on_setup(**kwargs)
         self._current_player = self.get_players()[self._current_player_idx]
+        self.state.game_id = kwargs.get("game_id", None)
 
     @final
     def before_game(self):
         self._on_before_game()
         self.current_round += 1
-        self.state.current_turn += 1
+        self.state.current_turn = 0
         self._on_before_round()
 
     @abc.abstractmethod

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -1,3 +1,25 @@
+"""
+Branching game runner for exploring multiple trajectories.
+
+This module provides functionality to run games with branching, where at certain decision points
+the game state is copied and multiple different responses are explored independently.
+
+Key concepts:
+- **Branching factor**: Number of parallel branches created when the condition is met
+- **Branching condition**: A callable that determines when to create branches
+- **Leaf branches**: The final completed game trajectories (e.g., 64 independent gameplays)
+
+The runner creates a tree structure where:
+- Each node represents a game state
+- Each branch explores a different response/action
+- Leaf nodes are complete game episodes
+
+Use cases:
+- Collecting multiple model responses for the same context
+- Exploring different dialogue paths
+- Generating diverse training data
+- Stochastic evaluation with repeated sampling
+"""
 import logging
 from typing import List, Optional
 from copy import deepcopy
@@ -112,36 +134,53 @@ def run(game_benchmark: GameBenchmark,
         branching_condition: Optional[BranchingCondition] = None
         ):
     """
-    Run game instances with optional branching.
+    Run game instances with optional branching to explore multiple trajectories.
+
+    This function executes games where, at certain decision points determined by the
+    branching_condition, the game state is copied and multiple different responses
+    are explored in parallel. This creates a tree of game trajectories.
 
     Args:
         game_benchmark: The game benchmark configuration
-        game_instances: Instances to play
-        player_models: List of player models
-        callbacks: Callbacks for benchmark events
-        branching_factor: Number of branches to create when condition is met (1 = no branching)
+        game_instances: Game instances to play (from instances.json)
+        player_models: List of player models to use
+        callbacks: Callbacks for benchmark lifecycle events
+        branching_factor: Number of branches to create when condition is met.
+            - 1 = no branching (default, standard gameplay)
+            - 2+ = create this many parallel branches at each branching point
         branching_condition: A callable(player, env, context) -> bool that determines
-            when to branch. If None, no branching occurs. The player parameter gives access
-            to the Player object including its model.
+            when to branch. If None, no branching occurs.
+            - player: The Player object (access to model, role, etc.)
+            - env: The GameMasterEnv (access to game state, round, etc.)
+            Returns True to trigger branching at this step.
+
+    Returns:
+        None. Results are saved via callbacks.
 
     Example:
         # Branch when the Describer role is active
-        run(..., branching_factor=3, branching_condition=player_role_condition("Describer"))
+        run(..., branching_factor=3, branching_condition=is_player_role("Describer"))
 
         # Branch when a specific model is active
-        run(..., branching_factor=2, branching_condition=player_model_condition("gpt-4"))
+        run(..., branching_factor=2, branching_condition=is_player_model(learner))
 
         # Branch only at first round
-        run(..., branching_factor=3, branching_condition=round_condition(1))
+        run(..., branching_factor=3, branching_condition=is_round(0))
 
         # Combine conditions: branch when learner model is active AND it's the first round
         run(..., branching_factor=2, branching_condition=combined_condition(
-            player_model_condition("learner-model"),
-            round_condition(1)
+            is_player_model(learner),
+            is_round(0)
         ))
 
-        # Or use a lambda for custom conditions
-        run(..., branching_factor=2, branching_condition=lambda player, **_: player.game_role == "GM")
+        # Custom condition using lambda
+        run(...,  branching_factor=2, branching_condition=lambda player, **_: player.game_role == "Guesser")
+
+    Notes:
+        - With branching_factor=N and M branching points, you get N^M leaf branches
+        - Each leaf branch is a complete, independent game trajectory
+        - Branching creates deep copies of the game state, so branches don't interfere
+        - Use **_ in lambda conditions to ignore unused parameters
     """
     callbacks.on_benchmark_start(game_benchmark)
     error_count = 0
@@ -170,6 +209,31 @@ def run(game_benchmark: GameBenchmark,
 
 
 class BranchingRunner:
+    """
+    Manages the execution of a branching game episode.
+
+    This runner maintains a list of active game environments and processes them
+    in parallel, creating new branches when the branching condition is met.
+
+    The runner uses a breadth-first approach:
+    1. Start with the root game environment
+    2. For each active environment:
+       - Check if branching should occur
+       - Create copies if branching
+       - Execute the next step for each branch
+    3. Continue until all branches complete
+
+    Attributes:
+        _root: The initial game environment
+        branching_factor: Number of branches to create when condition is met
+        branching_condition: Callable that determines when to branch
+        _current_envs: List of currently active game environments
+
+    Example:
+        runner = BranchingRunner(game_env, branching_factor=3, branching_condition=is_round(0))
+        runner.run()
+        # Results in 3 independent game trajectories
+    """
 
     def __init__(
             self,
@@ -184,6 +248,20 @@ class BranchingRunner:
         self._current_envs: List[GameMasterEnv] = [self._root]
 
     def should_branch(self, game_env):
+        """
+        Determine if branching should occur at the current step.
+
+        Args:
+            game_env: The current game environment
+
+        Returns:
+            bool: True if branching should occur, False otherwise
+
+        The method checks:
+        1. branching_factor > 1 (branching is enabled)
+        2. branching_condition is not None (a condition is specified)
+        3. branching_condition returns True for the current player/env
+        """
         agent_id = game_env.agent_selection
         player = game_env.player_by_agent_id[agent_id]
         return (

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -184,7 +184,8 @@ def run(game_benchmark: GameBenchmark,
     """
     callbacks.on_benchmark_start(game_benchmark)
     error_count = 0
-    for row in tqdm(game_instances, desc="Playing game instances"):
+    progress_bar = tqdm(game_instances, desc="Playing game instances")
+    for row in progress_bar:
         try:
             game_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
             game_env.reset(options={
@@ -194,7 +195,7 @@ def run(game_benchmark: GameBenchmark,
             })
             for model in player_models:
                 model.reset()
-            runner = BranchingRunner(game_env, branching_factor, branching_condition)
+            runner = BranchingRunner(game_env, branching_factor, branching_condition, progress_bar=progress_bar)
             runner.run()
         except Exception:
             message = f"{game_benchmark.game_name}: Exception for instance {row['game_instance']['game_id']} (but continue)"
@@ -239,12 +240,14 @@ class BranchingRunner:
             self,
             game_env: GameMasterEnv,
             branching_factor: int = 1,
-            branching_condition: Optional[BranchingCondition] = None
+            branching_condition: Optional[BranchingCondition] = None,
+            progress_bar=None
     ):
         self._root = game_env
         self.branching_factor = branching_factor
         self.branching_condition = branching_condition
 
+        self._progress_bar = progress_bar
         self._current_envs: List[GameMasterEnv] = [self._root]
 
     def should_branch(self, game_env):
@@ -263,6 +266,8 @@ class BranchingRunner:
         3. branching_condition returns True for the current player/env
         """
         agent_id = game_env.agent_selection
+        if agent_id is None:  # Game is done, no branching on terminal envs
+            return False
         player = game_env.player_by_agent_id[agent_id]
         return (
                 self.branching_factor > 1 and
@@ -272,26 +277,36 @@ class BranchingRunner:
 
     def run(self):
         while self._current_envs:  # As long as we have remaining game envs to be played ...
+            if self._progress_bar is not None:
+                self._progress_bar.set_postfix(branches=len(self._current_envs))
             remaining_envs = []
             for game_env in self._current_envs:  # ... we iterate over all of them
                 if self.should_branch(game_env):  # ... and branch for each game env if necessary
-                    branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor - 1)]
+                    branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor)]
                 else:
                     branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
-                for branch_env in branch_envs:  # ... then we continue the branches, or the game_env itself
-                    agent_id = branch_env.agent_selection  # Only select the next agent
-                    if agent_id is None:  # When there is no agent left, the episode is done for this game env
-                        branch_env.close()
-                        continue
-                    context, reward, termination, truncation, info = game_env.last(observe=True)
-                    if termination or truncation:
-                        # None actions remove the agent from the game during step(None)
-                        # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
-                        response = None
-                    else:
-                        player = branch_env.player_by_agent_id[agent_id]
-                        response = player(context)
-                    branch_env.step(response)
-                    # If we made it to here, then the branch is to be continued (agent_id was not None)
-                    remaining_envs.append(branch_env)
+                continued_branches = self._single_step_all(branch_envs)
+                remaining_envs.extend(continued_branches)
             self._current_envs = remaining_envs
+        if self._progress_bar is not None:
+            self._progress_bar.set_postfix(branches=0)
+
+    def _single_step_all(self, branch_envs):
+        continued_branches = []
+        for branch_env in branch_envs:
+            agent_id = branch_env.agent_selection
+            if agent_id is None:  # This was a terminal branch (we can safely ignore it)
+                branch_env.close()
+                continue
+            context, reward, termination, truncation, info = branch_env.last(observe=True)
+            if termination or truncation:
+                # None actions remove the agent from the game during step(None)
+                # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
+                response = None
+            else:
+                player = branch_env.player_by_agent_id[agent_id]
+                response = player(context)
+            branch_env.step(response)
+            # If we made it to here, then the branch is to be continued (agent_id was not None)
+            continued_branches.append(branch_env)
+        return continued_branches

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -31,6 +31,8 @@ from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenc
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
 from typing import Callable, TYPE_CHECKING
 
+from clemcore.clemgame.master import GameState
+
 if TYPE_CHECKING:
     from clemcore.clemgame.player import Player
 
@@ -125,14 +127,17 @@ def combined_condition(*conditions: BranchingCondition) -> BranchingCondition:
     return condition
 
 
-def run(game_benchmark: GameBenchmark,
+def run(
+        game_benchmark: GameBenchmark,
         game_instances: GameInstances,
         player_models: List[Model],
         *,
         callbacks: GameBenchmarkCallbackList,
         branching_factor: int = 1,
-        branching_condition: Optional[BranchingCondition] = lambda **_: True
-        ):
+        branching_condition: Optional[BranchingCondition] = lambda **_: True,
+        reward_func: Callable[[dict, str, GameState, dict], float] | None = None,
+        feedback_func: Callable[[dict, str, GameState, dict], str | None] | None = None
+):
     """
     Run game instances with optional branching to explore multiple trajectories.
 
@@ -153,7 +158,13 @@ def run(game_benchmark: GameBenchmark,
             - player: The Player object (access to model, role, etc.)
             - env: The GameMasterEnv (access to game state, round, etc.)
             Returns True to trigger branching at this step.
-
+        reward_func: a callable (observation, action, state, info) -> float to compute the reward signal.
+            Defaults to outcome-based rewards: 1. on success, 0. on failure, -1. on abort, 0. otherwise.
+            Game-specific rewards can be implemented by subclassing GameState to carry additional fields
+            (e.g. letter matches in Wordle) and reading them in a custom reward_func.
+        feedback_func: an optional callable (observation, action, state, info) -> str | None to provide
+            qualitative language feedback. When provided, the result is stored in info["turn_feedback"]
+            and can be used by the training loop (e.g. as a verbal reward signal).
     Returns:
         None. Results are saved via callbacks.
 
@@ -187,7 +198,12 @@ def run(game_benchmark: GameBenchmark,
     progress_bar = tqdm(game_instances, desc="Playing game instances")
     for row in progress_bar:
         try:
-            game_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
+            game_env = GameMasterEnv(
+                game_benchmark,
+                callbacks=callbacks,
+                reward_func=reward_func,
+                feedback_func=feedback_func
+            )
             game_env.reset(options={
                 "player_models": player_models,
                 "experiment": row["experiment"],

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -9,10 +9,10 @@ Key concepts:
 - **Branching condition**: A callable that determines when to create branches
 - **Leaf branches**: The final completed game trajectories (e.g., 64 independent gameplays)
 
-The runner creates a tree structure where:
-- Each node represents a game state
-- Each branch explores a different response/action
-- Leaf nodes are complete game episodes
+The runner maintains a flat pool of active environments. At each step:
+- Every active environment is checked against the branching condition
+- If the condition is met, the environment is copied branching_factor times
+- Each copy is then stepped forward independently
 
 Use cases:
 - Collecting multiple model responses for the same context
@@ -52,7 +52,7 @@ def is_player_role(game_role: str) -> BranchingCondition:
         A callable that returns True when the specified role is active
 
     Example:
-        condition = player_role_condition("Describer")
+        condition = is_player_role("Describer")
     """
 
     def condition(player: 'Player' = None, **_) -> bool:
@@ -72,7 +72,7 @@ def is_player_model(model: Model) -> BranchingCondition:
         A callable that returns True when the specified model is active
 
     Example:
-        condition = player_model_condition(learner_model)
+        condition = is_player_model(learner_model)
     """
 
     def condition(player: 'Player' = None, **_) -> bool:
@@ -208,107 +208,121 @@ def run(game_benchmark: GameBenchmark,
             f"{game_benchmark.game_name}: '{error_count}' exceptions occurred: See clembench.log for details.")
     callbacks.on_benchmark_end(game_benchmark)
 
-
-class BranchingRunner:
-    """
-    Manages the execution of a branching game episode.
-
-    This runner maintains a list of active game environments and processes them
-    in parallel, creating new branches when the branching condition is met.
-
-    The runner uses a breadth-first approach:
-    1. Start with the root game environment
-    2. For each active environment:
-       - Check if branching should occur
-       - Create copies if branching
-       - Execute the next step for each branch
-    3. Continue until all branches complete
-
-    Attributes:
-        _root: The initial game environment
-        branching_factor: Number of branches to create when condition is met
-        branching_condition: Callable that determines when to branch
-        _current_envs: List of currently active game environments
-
-    Example:
-        runner = BranchingRunner(game_env, branching_factor=3, branching_condition=is_round(0))
-        runner.run()
-        # Results in 3 independent game trajectories
-    """
-
-    def __init__(
-            self,
-            game_env: GameMasterEnv,
-            branching_factor: int = 1,
-            branching_condition: Optional[BranchingCondition] = lambda **_: True,
-            progress_bar=None
-    ):
-        self._root = game_env
-        self.branching_factor = branching_factor
-        self.branching_condition = branching_condition
-
-        self._progress_bar = progress_bar
-        self._current_envs: List[GameMasterEnv] = [self._root]
-
-    def should_branch(self, game_env):
+    class BranchingRunner:
         """
-        Determine if branching should occur at the current step.
+        Manages the execution of a branching game episode.
 
-        Args:
-            game_env: The current game environment
+        This runner maintains a flat list of active game environments and processes them
+        in parallel, creating new branches when the branching condition is met.
 
-        Returns:
-            bool: True if branching should occur, False otherwise
+        At each iteration:
+        1. Every active environment is checked against the branching condition
+        2. If the condition is met, the environment is deep-copied branching_factor times
+        3. Each copy is stepped forward independently
+        4. The resulting active environments form the pool for the next iteration
+        5. Continue until all environments have completed
 
-        The method checks:
-        1. branching_factor > 1 (branching is enabled)
-        2. branching_condition is not None (a condition is specified)
-        3. branching_condition returns True for the current player/env
+        Attributes:
+            _root: The initial game environment
+            branching_factor: Number of branches to create when condition is met
+            branching_condition: Callable that determines when to branch
+            _current_envs: List of currently active game environments
+
+        Example:
+            runner = BranchingRunner(game_env, branching_factor=3, branching_condition=is_round(0))
+            runner.run()
+            # Results in 3 independent game trajectories
         """
-        agent_id = game_env.agent_selection
-        if agent_id is None:
-            return False  # Don't branch terminal envs
-        if game_env.terminations.get(agent_id) or game_env.truncations.get(agent_id):
-            return False  # Don't branch on cleanup steps
-        player = game_env.player_by_agent_id[agent_id]
-        return (
-                self.branching_factor > 1 and
-                self.branching_condition is not None and
-                self.branching_condition(player=player, env=game_env)
-        )
 
-    def run(self):
-        while self._current_envs:  # As long as we have remaining game envs to be played ...
+        def __init__(
+                self,
+                game_env: GameMasterEnv,
+                branching_factor: int = 1,
+                branching_condition: Optional[BranchingCondition] = lambda **_: True,
+                progress_bar=None
+        ):
+            self._root = game_env
+            self.branching_factor = branching_factor
+            self.branching_condition = branching_condition
+
+            self._progress_bar = progress_bar
+            self._current_envs: List[GameMasterEnv] = [self._root]
+
+        def should_branch(self, game_env):
+            """
+            Determine if branching should occur at the current step.
+
+            Args:
+                game_env: The current game environment
+
+            Returns:
+                bool: True if branching should occur, False otherwise
+
+            The method checks:
+            1. branching_factor > 1 (branching is enabled)
+            2. branching_condition is not None (a condition is specified)
+            3. branching_condition returns True for the current player/env
+            """
+            agent_id = game_env.agent_selection
+            if agent_id is None:
+                return False  # Don't branch terminal envs
+            if game_env.terminations.get(agent_id) or game_env.truncations.get(agent_id):
+                return False  # Don't branch on cleanup steps
+            player = game_env.player_by_agent_id[agent_id]
+            return (
+                    self.branching_factor > 1 and
+                    self.branching_condition is not None and
+                    self.branching_condition(player=player, env=game_env)
+            )
+
+        def run(self):
+            while self._current_envs:  # As long as we have remaining game envs to be played ...
+                if self._progress_bar is not None:
+                    self._progress_bar.set_postfix(branches=len(self._current_envs))
+                remaining_envs = []
+                for game_env in self._current_envs:  # ... we iterate over all of them
+                    if self.should_branch(game_env):  # ... and branch for each game env if necessary
+                        branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor)]
+                    else:
+                        branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
+                    continued_branches = self._single_step_all(branch_envs)
+                    remaining_envs.extend(continued_branches)
+                self._current_envs = remaining_envs
             if self._progress_bar is not None:
-                self._progress_bar.set_postfix(branches=len(self._current_envs))
-            remaining_envs = []
-            for game_env in self._current_envs:  # ... we iterate over all of them
-                if self.should_branch(game_env):  # ... and branch for each game env if necessary
-                    branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor)]
-                else:
-                    branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
-                continued_branches = self._single_step_all(branch_envs)
-                remaining_envs.extend(continued_branches)
-            self._current_envs = remaining_envs
-        if self._progress_bar is not None:
-            self._progress_bar.set_postfix(branches=0)
+                self._progress_bar.set_postfix(branches=0)
 
-    def _single_step_all(self, branch_envs):
-        continued_branches = []
-        for branch_env in branch_envs:
-            agent_id = branch_env.agent_selection
-            if agent_id is None:  # This was a terminal branch (we can safely ignore it)
-                branch_env.close()
-                continue
-            context, reward, termination, truncation, info = branch_env.last(observe=True)
-            if termination or truncation:
-                # None actions remove the agent from the game during step(None)
-                # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
-                response = None
-            else:
-                player = branch_env.player_by_agent_id[agent_id]
-                response = player(context)
-            branch_env.step(response)
-            # If we made it to here, then the branch is to be continued (agent_id was not None)
-            continued_branches.append(branch_env)
-        return continued_branches
+        def _single_step_all(self, branch_envs):
+            """
+            Execute a single step for each branch environment.
+
+            For each environment, observes the current context and computes
+            a response via the active player. Terminal or truncated agents
+            receive a ``None`` action to allow final reward observation before
+            the environment is closed.
+
+            Args:
+                branch_envs: List of game environments to step through.
+
+            Returns:
+                List of branch environments that are still active after the step.
+                Environments whose ``agent_selection`` is ``None`` (terminal) are
+                closed and excluded from the returned list.
+            """
+            continued_branches = []
+            for branch_env in branch_envs:
+                agent_id = branch_env.agent_selection
+                if agent_id is None:  # This was a terminal branch (we can safely ignore it)
+                    branch_env.close()
+                    continue
+                context, reward, termination, truncation, info = branch_env.last(observe=True)
+                if termination or truncation:
+                    # None actions remove the agent from the game during step(None)
+                    # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
+                    response = None
+                else:
+                    player = branch_env.player_by_agent_id[agent_id]
+                    response = player(context)
+                branch_env.step(response)
+                # If we made it to here, then the branch is to be continued (agent_id was not None)
+                continued_branches.append(branch_env)
+            return continued_branches

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -276,16 +276,28 @@ class BranchingRunner:
                 self.branching_condition(player=player, env=game_env)
         )
 
+    @staticmethod
+    def to_parent_id(game_env: GameMasterEnv) -> str:
+        return (f"{game_env.metadata.get('name')}"
+                f"-{game_env.experiment['name']}"
+                f"-{game_env.game_instance['game_id']}"
+                f"-turn_{game_env.game_master.state.current_turn}")
+
     def run(self):
         while self._current_envs:  # As long as we have remaining game envs to be played ...
             if self._progress_bar is not None:
                 self._progress_bar.set_postfix(branches=len(self._current_envs))
             remaining_envs = []
-            for game_env in self._current_envs:  # ... we iterate over all of them
-                if self.should_branch(game_env):  # ... and branch for each game env if necessary
-                    branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor)]
-                else:
-                    branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
+            for parent_env in self._current_envs:  # ... we iterate over all of them
+                parent_id = BranchingRunner.to_parent_id(parent_env)
+                branch_envs = []
+                num_branches = 1  # by default, we do not branch
+                if self.should_branch(parent_env):
+                    num_branches = self.branching_factor
+                for _ in range(num_branches):
+                    branch_env = deepcopy(parent_env)
+                    branch_env.callbacks.on_branch_start(branch_env.game_master, branch_env.game_instance, parent_id)
+                    branch_envs.append(branch_env)
                 continued_branches = self._single_step_all(branch_envs)
                 remaining_envs.extend(continued_branches)
             self._current_envs = remaining_envs

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Callable, Optional
+from typing import List, Callable, Optional, TYPE_CHECKING
 from copy import deepcopy
 
 from tqdm import tqdm
@@ -8,20 +8,23 @@ from clemcore.backends import Model
 from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenchmark
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
 
+if TYPE_CHECKING:
+    from clemcore.clemgame.player import Player
+
 module_logger = logging.getLogger(__name__)
 stdout_logger = logging.getLogger("clemcore.run")
 
 
 # Type alias for branching condition callable
-BranchingCondition = Callable[[GameMasterEnv, str, any], bool]
+BranchingCondition = Callable[..., bool]
 
 
-def player_role_condition(role_name: str) -> BranchingCondition:
+def is_player_role(game_role: str) -> BranchingCondition:
     """
     Create a branching condition that triggers when a specific player role is active.
     
     Args:
-        role_name: The role name to branch on (e.g., "Describer", "GM")
+        game_role: The role name to branch on, e.g., "WordDescriber"
         
     Returns:
         A callable that returns True when the specified role is active
@@ -29,11 +32,66 @@ def player_role_condition(role_name: str) -> BranchingCondition:
     Example:
         condition = player_role_condition("Describer")
     """
-    def condition(game_env: GameMasterEnv, agent_id: str, context: any) -> bool:
-        player = game_env.player_by_agent_id.get(agent_id)
-        if player is None:
-            return False
-        return hasattr(player, 'role') and player.role == role_name
+    def condition(player: 'Player' = None, **_) -> bool:
+        return player is not None and hasattr(player, 'game_role') and player.game_role == game_role
+    return condition
+
+
+def is_player_model(model: Model) -> BranchingCondition:
+    """
+    Create a branching condition that triggers when a specific model is active.
+
+    Args:
+        model: The model to branch on
+
+    Returns:
+        A callable that returns True when the specified model is active
+
+    Example:
+        condition = player_model_condition(learner_model)
+    """
+    def condition(player: 'Player' = None, **_) -> bool:
+        return player is not None and hasattr(player, 'model') and player.model is model
+    return condition
+
+
+def is_round(round_number: int) -> BranchingCondition:
+    """
+    Create a branching condition that triggers at a specific round.
+    
+    Args:
+        round_number: The round number to branch on (0-indexed)
+        
+    Returns:
+        A callable that returns True at the specified round
+        
+    Example:
+        condition = round_condition(0)  # Branch only at first round
+    """
+    def condition(env: GameMasterEnv = None, **_) -> bool:
+        gm = env.game_master if env is not None else None
+        return gm is not None and hasattr(gm, 'current_round') and gm.current_round == round_number
+    return condition
+
+
+def combined_condition(*conditions: BranchingCondition) -> BranchingCondition:
+    """
+    Combine multiple branching conditions with AND logic.
+    
+    Args:
+        *conditions: Variable number of branching conditions
+        
+    Returns:
+        A callable that returns True only when all conditions are True
+        
+    Example:
+        condition = combined_condition(
+            is_player_role("Describer"),
+            is_round(0)
+        )
+    """
+    def condition(player: 'Player', env: GameMasterEnv, context: any) -> bool:
+        return all(cond(player=player, env=env, context=context) for cond in conditions)
     return condition
 
 
@@ -65,15 +123,28 @@ def run(game_benchmark: GameBenchmark,
         player_models: List of player models
         callbacks: Callbacks for benchmark events
         branching_factor: Number of branches to create when condition is met (1 = no branching)
-        branching_condition: A callable(game_env, agent_id, context) -> bool that determines
-            when to branch. If None, no branching occurs.
+        branching_condition: A callable(player, env, context) -> bool that determines
+            when to branch. If None, no branching occurs. The player parameter gives access
+            to the Player object including its model.
             
     Example:
         # Branch when the Describer role is active
         run(..., branching_factor=3, branching_condition=player_role_condition("Describer"))
         
-        # Or use a lambda for simple conditions
-        run(..., branching_factor=2, branching_condition=lambda env, agent, ctx: agent == "player_1")
+        # Branch when a specific model is active
+        run(..., branching_factor=2, branching_condition=player_model_condition("gpt-4"))
+        
+        # Branch only at first round
+        run(..., branching_factor=3, branching_condition=round_condition(1))
+        
+        # Combine conditions: branch when learner model is active AND it's the first round
+        run(..., branching_factor=2, branching_condition=combined_condition(
+            player_model_condition("learner-model"),
+            round_condition(1)
+        ))
+        
+        # Or use a lambda for custom conditions
+        run(..., branching_factor=2, branching_condition=lambda player, **_: player.game_role == "GM")
     """
     callbacks.on_benchmark_start(game_benchmark)
     error_count = 0
@@ -118,12 +189,14 @@ def run(game_benchmark: GameBenchmark,
                                 branch.completed = True
                                 break
                             
+                            player = branch.game_env.player_by_agent_id[agent_id]
+                            
                             # Check if we should branch at this step
                             should_branch = (
                                 not has_branched and 
                                 branching_factor > 1 and 
                                 branching_condition is not None and
-                                branching_condition(branch.game_env, agent_id, context)
+                                branching_condition(player=player, env=branch.game_env, context=context)
                             )
                             
                             if should_branch:
@@ -155,7 +228,6 @@ def run(game_benchmark: GameBenchmark,
                                 )
                             
                             # Generate response for current branch
-                            player = branch.game_env.player_by_agent_id[agent_id]
                             response = player(context)
                             branch.game_env.step(response)
                             

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -293,7 +293,7 @@ class BranchingRunner:
         )
 
     @staticmethod
-    def to_parent_id(game_env: GameMasterEnv) -> str:
+    def to_branching_point_id(game_env: GameMasterEnv) -> str:
         return (f"{game_env.metadata.get('name')}"
                 f"-{game_env.experiment['name']}"
                 f"-{game_env.game_instance['game_id']}"
@@ -305,14 +305,18 @@ class BranchingRunner:
                 self._progress_bar.set_postfix(branches=len(self._current_envs))
             remaining_envs = []
             for parent_env in self._current_envs:  # ... we iterate over all of them
-                parent_id = BranchingRunner.to_parent_id(parent_env)
+                branching_point_id = BranchingRunner.to_branching_point_id(parent_env)
                 branch_envs = []
                 num_branches = 1  # by default, we do not branch
                 if self.should_branch(parent_env):
                     num_branches = self.branching_factor
                 for _ in range(num_branches):
                     branch_env = deepcopy(parent_env)
-                    branch_env.callbacks.on_branch_start(branch_env.game_master, branch_env.game_instance, parent_id)
+                    branch_env.callbacks.on_branch_start(
+                        branch_env.game_master,
+                        branch_env.game_instance,
+                        branching_point_id
+                    )
                     branch_envs.append(branch_env)
                 continued_branches = self._single_step_all(branch_envs)
                 remaining_envs.extend(continued_branches)

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 from tqdm import tqdm
 
 from clemcore.backends import Model
-from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenchmark
+from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenchmark, GameSnapshot
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
 from typing import Callable, TYPE_CHECKING
 
@@ -263,7 +263,7 @@ class BranchingRunner:
         self.branching_condition = branching_condition
 
         self._progress_bar = progress_bar
-        self._current_envs: List[GameMasterEnv] = [self._root]
+        self._current_envs: list[GameMasterEnv] = [self._root]
 
     def should_branch(self, game_env):
         """
@@ -292,39 +292,33 @@ class BranchingRunner:
                 self.branching_condition(player=player, env=game_env)
         )
 
-    @staticmethod
-    def to_branching_point_id(game_env: GameMasterEnv) -> str:
-        return (f"{game_env.metadata.get('name')}"
-                f"-{game_env.experiment['name']}"
-                f"-{game_env.game_instance['game_id']}"
-                f"-turn_{game_env.game_master.state.current_turn}")
-
     def run(self):
         while self._current_envs:  # As long as we have remaining game envs to be played ...
             if self._progress_bar is not None:
                 self._progress_bar.set_postfix(branches=len(self._current_envs))
-            remaining_envs = []
+            remaining_envs: list[GameMasterEnv] = []
             for parent_env in self._current_envs:  # ... we iterate over all of them
-                branching_point_id = BranchingRunner.to_branching_point_id(parent_env)
+                snapshot = GameSnapshot.create_from(parent_env.game_master)
                 branch_envs = []
-                num_branches = 1  # by default, we do not branch
                 if self.should_branch(parent_env):
                     num_branches = self.branching_factor
-                for _ in range(num_branches):
-                    branch_env = deepcopy(parent_env)
-                    branch_env.callbacks.on_branching_point(
-                        branch_env.game_master,
-                        branch_env.game_instance,
-                        branching_point_id
-                    )
-                    branch_envs.append(branch_env)
+                    for _ in range(num_branches):
+                        branch_env = deepcopy(parent_env)
+                        branch_env.callbacks.on_branching_point(
+                            branch_env.game_master,
+                            branch_env.game_instance,
+                            snapshot
+                        )
+                        branch_envs.append(branch_env)
+                else:
+                    branch_envs.append(deepcopy(parent_env))
                 continued_branches = self._single_step_all(branch_envs)
                 remaining_envs.extend(continued_branches)
             self._current_envs = remaining_envs
         if self._progress_bar is not None:
             self._progress_bar.set_postfix(branches=0)
 
-    def _single_step_all(self, branch_envs):
+    def _single_step_all(self, branch_envs: list[GameMasterEnv]) -> list[GameMasterEnv]:
         """
         Execute a single step for each branch environment.
 
@@ -341,7 +335,7 @@ class BranchingRunner:
             Environments whose ``agent_selection`` is ``None`` (terminal) are
             closed and excluded from the returned list.
         """
-        continued_branches = []
+        continued_branches: list[GameMasterEnv] = []
         for branch_env in branch_envs:
             agent_id = branch_env.agent_selection
             if agent_id is None:  # This was a terminal branch (we can safely ignore it)

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -208,121 +208,122 @@ def run(game_benchmark: GameBenchmark,
             f"{game_benchmark.game_name}: '{error_count}' exceptions occurred: See clembench.log for details.")
     callbacks.on_benchmark_end(game_benchmark)
 
-    class BranchingRunner:
+
+class BranchingRunner:
+    """
+    Manages the execution of a branching game episode.
+
+    This runner maintains a flat list of active game environments and processes them
+    in parallel, creating new branches when the branching condition is met.
+
+    At each iteration:
+    1. Every active environment is checked against the branching condition
+    2. If the condition is met, the environment is deep-copied branching_factor times
+    3. Each copy is stepped forward independently
+    4. The resulting active environments form the pool for the next iteration
+    5. Continue until all environments have completed
+
+    Attributes:
+        _root: The initial game environment
+        branching_factor: Number of branches to create when condition is met
+        branching_condition: Callable that determines when to branch
+        _current_envs: List of currently active game environments
+
+    Example:
+        runner = BranchingRunner(game_env, branching_factor=3, branching_condition=is_round(0))
+        runner.run()
+        # Results in 3 independent game trajectories
+    """
+
+    def __init__(
+            self,
+            game_env: GameMasterEnv,
+            branching_factor: int = 1,
+            branching_condition: Optional[BranchingCondition] = lambda **_: True,
+            progress_bar=None
+    ):
+        self._root = game_env
+        self.branching_factor = branching_factor
+        self.branching_condition = branching_condition
+
+        self._progress_bar = progress_bar
+        self._current_envs: List[GameMasterEnv] = [self._root]
+
+    def should_branch(self, game_env):
         """
-        Manages the execution of a branching game episode.
+        Determine if branching should occur at the current step.
 
-        This runner maintains a flat list of active game environments and processes them
-        in parallel, creating new branches when the branching condition is met.
+        Args:
+            game_env: The current game environment
 
-        At each iteration:
-        1. Every active environment is checked against the branching condition
-        2. If the condition is met, the environment is deep-copied branching_factor times
-        3. Each copy is stepped forward independently
-        4. The resulting active environments form the pool for the next iteration
-        5. Continue until all environments have completed
+        Returns:
+            bool: True if branching should occur, False otherwise
 
-        Attributes:
-            _root: The initial game environment
-            branching_factor: Number of branches to create when condition is met
-            branching_condition: Callable that determines when to branch
-            _current_envs: List of currently active game environments
-
-        Example:
-            runner = BranchingRunner(game_env, branching_factor=3, branching_condition=is_round(0))
-            runner.run()
-            # Results in 3 independent game trajectories
+        The method checks:
+        1. branching_factor > 1 (branching is enabled)
+        2. branching_condition is not None (a condition is specified)
+        3. branching_condition returns True for the current player/env
         """
+        agent_id = game_env.agent_selection
+        if agent_id is None:
+            return False  # Don't branch terminal envs
+        if game_env.terminations.get(agent_id) or game_env.truncations.get(agent_id):
+            return False  # Don't branch on cleanup steps
+        player = game_env.player_by_agent_id[agent_id]
+        return (
+                self.branching_factor > 1 and
+                self.branching_condition is not None and
+                self.branching_condition(player=player, env=game_env)
+        )
 
-        def __init__(
-                self,
-                game_env: GameMasterEnv,
-                branching_factor: int = 1,
-                branching_condition: Optional[BranchingCondition] = lambda **_: True,
-                progress_bar=None
-        ):
-            self._root = game_env
-            self.branching_factor = branching_factor
-            self.branching_condition = branching_condition
-
-            self._progress_bar = progress_bar
-            self._current_envs: List[GameMasterEnv] = [self._root]
-
-        def should_branch(self, game_env):
-            """
-            Determine if branching should occur at the current step.
-
-            Args:
-                game_env: The current game environment
-
-            Returns:
-                bool: True if branching should occur, False otherwise
-
-            The method checks:
-            1. branching_factor > 1 (branching is enabled)
-            2. branching_condition is not None (a condition is specified)
-            3. branching_condition returns True for the current player/env
-            """
-            agent_id = game_env.agent_selection
-            if agent_id is None:
-                return False  # Don't branch terminal envs
-            if game_env.terminations.get(agent_id) or game_env.truncations.get(agent_id):
-                return False  # Don't branch on cleanup steps
-            player = game_env.player_by_agent_id[agent_id]
-            return (
-                    self.branching_factor > 1 and
-                    self.branching_condition is not None and
-                    self.branching_condition(player=player, env=game_env)
-            )
-
-        def run(self):
-            while self._current_envs:  # As long as we have remaining game envs to be played ...
-                if self._progress_bar is not None:
-                    self._progress_bar.set_postfix(branches=len(self._current_envs))
-                remaining_envs = []
-                for game_env in self._current_envs:  # ... we iterate over all of them
-                    if self.should_branch(game_env):  # ... and branch for each game env if necessary
-                        branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor)]
-                    else:
-                        branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
-                    continued_branches = self._single_step_all(branch_envs)
-                    remaining_envs.extend(continued_branches)
-                self._current_envs = remaining_envs
+    def run(self):
+        while self._current_envs:  # As long as we have remaining game envs to be played ...
             if self._progress_bar is not None:
-                self._progress_bar.set_postfix(branches=0)
-
-        def _single_step_all(self, branch_envs):
-            """
-            Execute a single step for each branch environment.
-
-            For each environment, observes the current context and computes
-            a response via the active player. Terminal or truncated agents
-            receive a ``None`` action to allow final reward observation before
-            the environment is closed.
-
-            Args:
-                branch_envs: List of game environments to step through.
-
-            Returns:
-                List of branch environments that are still active after the step.
-                Environments whose ``agent_selection`` is ``None`` (terminal) are
-                closed and excluded from the returned list.
-            """
-            continued_branches = []
-            for branch_env in branch_envs:
-                agent_id = branch_env.agent_selection
-                if agent_id is None:  # This was a terminal branch (we can safely ignore it)
-                    branch_env.close()
-                    continue
-                context, reward, termination, truncation, info = branch_env.last(observe=True)
-                if termination or truncation:
-                    # None actions remove the agent from the game during step(None)
-                    # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
-                    response = None
+                self._progress_bar.set_postfix(branches=len(self._current_envs))
+            remaining_envs = []
+            for game_env in self._current_envs:  # ... we iterate over all of them
+                if self.should_branch(game_env):  # ... and branch for each game env if necessary
+                    branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor)]
                 else:
-                    player = branch_env.player_by_agent_id[agent_id]
-                    response = player(context)
-                branch_env.step(response)
-                # If we made it to here, then the branch is to be continued (agent_id was not None)
-                continued_branches.append(branch_env)
-            return continued_branches
+                    branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
+                continued_branches = self._single_step_all(branch_envs)
+                remaining_envs.extend(continued_branches)
+            self._current_envs = remaining_envs
+        if self._progress_bar is not None:
+            self._progress_bar.set_postfix(branches=0)
+
+    def _single_step_all(self, branch_envs):
+        """
+        Execute a single step for each branch environment.
+
+        For each environment, observes the current context and computes
+        a response via the active player. Terminal or truncated agents
+        receive a ``None`` action to allow final reward observation before
+        the environment is closed.
+
+        Args:
+            branch_envs: List of game environments to step through.
+
+        Returns:
+            List of branch environments that are still active after the step.
+            Environments whose ``agent_selection`` is ``None`` (terminal) are
+            closed and excluded from the returned list.
+        """
+        continued_branches = []
+        for branch_env in branch_envs:
+            agent_id = branch_env.agent_selection
+            if agent_id is None:  # This was a terminal branch (we can safely ignore it)
+                branch_env.close()
+                continue
+            context, reward, termination, truncation, info = branch_env.last(observe=True)
+            if termination or truncation:
+                # None actions remove the agent from the game during step(None)
+                # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
+                response = None
+            else:
+                player = branch_env.player_by_agent_id[agent_id]
+                response = player(context)
+            branch_env.step(response)
+            # If we made it to here, then the branch is to be continued (agent_id was not None)
+            continued_branches.append(branch_env)
+        return continued_branches

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -12,40 +12,29 @@ module_logger = logging.getLogger(__name__)
 stdout_logger = logging.getLogger("clemcore.run")
 
 
-class BranchingCondition:
-    """Base class for branching conditions."""
+# Type alias for branching condition callable
+BranchingCondition = Callable[[GameMasterEnv, str, any], bool]
+
+
+def player_role_condition(role_name: str) -> BranchingCondition:
+    """
+    Create a branching condition that triggers when a specific player role is active.
     
-    def should_branch(self, game_env: GameMasterEnv, agent_id: str, context: any) -> bool:
-        """
-        Determine if branching should occur at this step.
+    Args:
+        role_name: The role name to branch on (e.g., "Describer", "GM")
         
-        Args:
-            game_env: The game environment
-            agent_id: Current agent ID
-            context: Current observation/context
-            
-        Returns:
-            True if branching should occur, False otherwise
-        """
-        raise NotImplementedError
-
-
-class PlayerRoleBranchingCondition(BranchingCondition):
-    """Branch when a specific player role is active."""
-    
-    def __init__(self, role_name: str):
-        """
-        Args:
-            role_name: The role name to branch on (e.g., "Describer", "GM")
-        """
-        self.role_name = role_name
-    
-    def should_branch(self, game_env: GameMasterEnv, agent_id: str, context: any) -> bool:
+    Returns:
+        A callable that returns True when the specified role is active
+        
+    Example:
+        condition = player_role_condition("Describer")
+    """
+    def condition(game_env: GameMasterEnv, agent_id: str, context: any) -> bool:
         player = game_env.player_by_agent_id.get(agent_id)
         if player is None:
             return False
-        # Check if player has a role attribute matching our target
-        return hasattr(player, 'role') and player.role == self.role_name
+        return hasattr(player, 'role') and player.role == role_name
+    return condition
 
 
 class GameBranch:
@@ -76,7 +65,15 @@ def run(game_benchmark: GameBenchmark,
         player_models: List of player models
         callbacks: Callbacks for benchmark events
         branching_factor: Number of branches to create when condition is met (1 = no branching)
-        branching_condition: Condition that triggers branching. If None, no branching occurs.
+        branching_condition: A callable(game_env, agent_id, context) -> bool that determines
+            when to branch. If None, no branching occurs.
+            
+    Example:
+        # Branch when the Describer role is active
+        run(..., branching_factor=3, branching_condition=player_role_condition("Describer"))
+        
+        # Or use a lambda for simple conditions
+        run(..., branching_factor=2, branching_condition=lambda env, agent, ctx: agent == "player_1")
     """
     callbacks.on_benchmark_start(game_benchmark)
     error_count = 0
@@ -126,7 +123,7 @@ def run(game_benchmark: GameBenchmark,
                                 not has_branched and 
                                 branching_factor > 1 and 
                                 branching_condition is not None and
-                                branching_condition.should_branch(branch.game_env, agent_id, context)
+                                branching_condition(branch.game_env, agent_id, context)
                             )
                             
                             if should_branch:

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -266,8 +266,10 @@ class BranchingRunner:
         3. branching_condition returns True for the current player/env
         """
         agent_id = game_env.agent_selection
-        if agent_id is None:  # Game is done, no branching on terminal envs
-            return False
+        if agent_id is None:
+            return False  # Don't branch terminal envs
+        if game_env.terminations.get(agent_id) or game_env.truncations.get(agent_id):
+            return False  # Don't branch on cleanup steps
         player = game_env.player_by_agent_id[agent_id]
         return (
                 self.branching_factor > 1 and

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -131,7 +131,7 @@ def run(game_benchmark: GameBenchmark,
         *,
         callbacks: GameBenchmarkCallbackList,
         branching_factor: int = 1,
-        branching_condition: Optional[BranchingCondition] = None
+        branching_condition: Optional[BranchingCondition] = lambda **_: True
         ):
     """
     Run game instances with optional branching to explore multiple trajectories.
@@ -149,7 +149,7 @@ def run(game_benchmark: GameBenchmark,
             - 1 = no branching (default, standard gameplay)
             - 2+ = create this many parallel branches at each branching point
         branching_condition: A callable(player, env, context) -> bool that determines
-            when to branch. If None, no branching occurs.
+            when to branch. If None, no branching occurs. Default: always True.
             - player: The Player object (access to model, role, etc.)
             - env: The GameMasterEnv (access to game state, round, etc.)
             Returns True to trigger branching at this step.
@@ -240,7 +240,7 @@ class BranchingRunner:
             self,
             game_env: GameMasterEnv,
             branching_factor: int = 1,
-            branching_condition: Optional[BranchingCondition] = None,
+            branching_condition: Optional[BranchingCondition] = lambda **_: True,
             progress_bar=None
     ):
         self._root = game_env

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -312,7 +312,7 @@ class BranchingRunner:
                     num_branches = self.branching_factor
                 for _ in range(num_branches):
                     branch_env = deepcopy(parent_env)
-                    branch_env.callbacks.on_branch_start(
+                    branch_env.callbacks.on_branching_point(
                         branch_env.game_master,
                         branch_env.game_instance,
                         branching_point_id

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -1,0 +1,199 @@
+import logging
+from typing import List, Callable, Optional
+from copy import deepcopy
+
+from tqdm import tqdm
+
+from clemcore.backends import Model
+from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenchmark
+from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
+
+module_logger = logging.getLogger(__name__)
+stdout_logger = logging.getLogger("clemcore.run")
+
+
+class BranchingCondition:
+    """Base class for branching conditions."""
+    
+    def should_branch(self, game_env: GameMasterEnv, agent_id: str, context: any) -> bool:
+        """
+        Determine if branching should occur at this step.
+        
+        Args:
+            game_env: The game environment
+            agent_id: Current agent ID
+            context: Current observation/context
+            
+        Returns:
+            True if branching should occur, False otherwise
+        """
+        raise NotImplementedError
+
+
+class PlayerRoleBranchingCondition(BranchingCondition):
+    """Branch when a specific player role is active."""
+    
+    def __init__(self, role_name: str):
+        """
+        Args:
+            role_name: The role name to branch on (e.g., "Describer", "GM")
+        """
+        self.role_name = role_name
+    
+    def should_branch(self, game_env: GameMasterEnv, agent_id: str, context: any) -> bool:
+        player = game_env.player_by_agent_id.get(agent_id)
+        if player is None:
+            return False
+        # Check if player has a role attribute matching our target
+        return hasattr(player, 'role') and player.role == self.role_name
+
+
+class GameBranch:
+    """Represents a single branch of gameplay."""
+    
+    def __init__(self, branch_id: int, game_env: GameMasterEnv, player_models: List[Model]):
+        self.branch_id = branch_id
+        self.game_env = game_env
+        self.player_models = player_models
+        self.completed = False
+        self.error = None
+
+
+def run(game_benchmark: GameBenchmark,
+        game_instances: GameInstances,
+        player_models: List[Model],
+        *,
+        callbacks: GameBenchmarkCallbackList,
+        branching_factor: int = 1,
+        branching_condition: Optional[BranchingCondition] = None
+        ):
+    """
+    Run game instances with optional branching.
+    
+    Args:
+        game_benchmark: The game benchmark configuration
+        game_instances: Instances to play
+        player_models: List of player models
+        callbacks: Callbacks for benchmark events
+        branching_factor: Number of branches to create when condition is met (1 = no branching)
+        branching_condition: Condition that triggers branching. If None, no branching occurs.
+    """
+    callbacks.on_benchmark_start(game_benchmark)
+    error_count = 0
+    
+    for row in tqdm(game_instances, desc="Playing game instances"):
+        try:
+            # Initialize the first branch
+            game_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
+            game_env.reset(options={
+                "player_models": player_models,
+                "experiment": row["experiment"],
+                "game_instance": row["game_instance"]
+            })
+            
+            for model in player_models:
+                model.reset()
+            
+            # Track active branches
+            branches = [GameBranch(0, game_env, player_models)]
+            branch_counter = 1
+            has_branched = False
+            
+            # Play all branches
+            while branches:
+                # Process each active branch
+                new_branches = []
+                
+                for branch in branches:
+                    if branch.completed:
+                        continue
+                    
+                    try:
+                        # Get next agent in this branch
+                        agent_iter = branch.game_env.agent_iter()
+                        
+                        for agent_id in agent_iter:
+                            context, reward, termination, truncation, info = branch.game_env.last(observe=True)
+                            
+                            if termination or truncation:
+                                response = None
+                                branch.game_env.step(response)
+                                branch.completed = True
+                                break
+                            
+                            # Check if we should branch at this step
+                            should_branch = (
+                                not has_branched and 
+                                branching_factor > 1 and 
+                                branching_condition is not None and
+                                branching_condition.should_branch(branch.game_env, agent_id, context)
+                            )
+                            
+                            if should_branch:
+                                # Create additional branches
+                                for i in range(branching_factor - 1):
+                                    # Create a new game environment for the branch
+                                    new_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
+                                    new_models = [deepcopy(model) for model in branch.player_models]
+                                    
+                                    # Reset with same configuration
+                                    new_env.reset(options={
+                                        "player_models": new_models,
+                                        "experiment": row["experiment"],
+                                        "game_instance": row["game_instance"]
+                                    })
+                                    
+                                    # TODO: Replay history to reach current state
+                                    # This is a simplified version - full implementation would need
+                                    # to replay all previous actions to reach the current game state
+                                    
+                                    new_branch = GameBranch(branch_counter, new_env, new_models)
+                                    new_branches.append(new_branch)
+                                    branch_counter += 1
+                                
+                                has_branched = True
+                                module_logger.info(
+                                    f"Branched instance {row['game_instance']['game_id']} "
+                                    f"into {branching_factor} branches at agent {agent_id}"
+                                )
+                            
+                            # Generate response for current branch
+                            player = branch.game_env.player_by_agent_id[agent_id]
+                            response = player(context)
+                            branch.game_env.step(response)
+                            
+                    except Exception as e:
+                        branch.error = e
+                        branch.completed = True
+                        module_logger.exception(
+                            f"Exception in branch {branch.branch_id} of instance "
+                            f"{row['game_instance']['game_id']}"
+                        )
+                        error_count += 1
+                
+                # Add new branches to active branches
+                branches.extend(new_branches)
+                
+                # Remove completed branches
+                branches = [b for b in branches if not b.completed]
+            
+            # Clean up
+            for branch in branches:
+                branch.game_env.close()
+            
+            # Reset models after all branches complete
+            for model in player_models:
+                model.reset()
+                
+        except Exception:
+            message = f"{game_benchmark.game_name}: Exception for instance {row['game_instance']['game_id']} (but continue)"
+            module_logger.exception(message)
+            error_count += 1
+            for model in player_models:
+                model.reset()
+    
+    if error_count > 0:
+        stdout_logger.error(
+            f"{game_benchmark.game_name}: '{error_count}' exceptions occurred: See clembench.log for details.")
+    
+    callbacks.on_benchmark_end(game_benchmark)

--- a/clemcore/clemgame/runners/branching.py
+++ b/clemcore/clemgame/runners/branching.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Callable, Optional, TYPE_CHECKING
+from typing import List, Optional
 from copy import deepcopy
 
 from tqdm import tqdm
@@ -7,13 +7,13 @@ from tqdm import tqdm
 from clemcore.backends import Model
 from clemcore.clemgame import GameBenchmarkCallbackList, GameInstances, GameBenchmark
 from clemcore.clemgame.envs.pettingzoo.master import GameMasterEnv
+from typing import Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from clemcore.clemgame.player import Player
 
 module_logger = logging.getLogger(__name__)
 stdout_logger = logging.getLogger("clemcore.run")
-
 
 # Type alias for branching condition callable
 BranchingCondition = Callable[..., bool]
@@ -22,18 +22,20 @@ BranchingCondition = Callable[..., bool]
 def is_player_role(game_role: str) -> BranchingCondition:
     """
     Create a branching condition that triggers when a specific player role is active.
-    
+
     Args:
         game_role: The role name to branch on, e.g., "WordDescriber"
-        
+
     Returns:
         A callable that returns True when the specified role is active
-        
+
     Example:
         condition = player_role_condition("Describer")
     """
+
     def condition(player: 'Player' = None, **_) -> bool:
         return player is not None and hasattr(player, 'game_role') and player.game_role == game_role
+
     return condition
 
 
@@ -50,60 +52,55 @@ def is_player_model(model: Model) -> BranchingCondition:
     Example:
         condition = player_model_condition(learner_model)
     """
+
     def condition(player: 'Player' = None, **_) -> bool:
         return player is not None and hasattr(player, 'model') and player.model is model
+
     return condition
 
 
 def is_round(round_number: int) -> BranchingCondition:
     """
     Create a branching condition that triggers at a specific round.
-    
+
     Args:
         round_number: The round number to branch on (0-indexed)
-        
+
     Returns:
         A callable that returns True at the specified round
-        
+
     Example:
         condition = round_condition(0)  # Branch only at first round
     """
+
     def condition(env: GameMasterEnv = None, **_) -> bool:
         gm = env.game_master if env is not None else None
         return gm is not None and hasattr(gm, 'current_round') and gm.current_round == round_number
+
     return condition
 
 
 def combined_condition(*conditions: BranchingCondition) -> BranchingCondition:
     """
     Combine multiple branching conditions with AND logic.
-    
+
     Args:
         *conditions: Variable number of branching conditions
-        
+
     Returns:
         A callable that returns True only when all conditions are True
-        
+
     Example:
         condition = combined_condition(
             is_player_role("Describer"),
             is_round(0)
         )
     """
-    def condition(player: 'Player', env: GameMasterEnv, context: any) -> bool:
-        return all(cond(player=player, env=env, context=context) for cond in conditions)
+
+    def condition(player: 'Player', env: GameMasterEnv) -> bool:
+        return all(cond(player=player, env=env) for cond in conditions)
+
     return condition
-
-
-class GameBranch:
-    """Represents a single branch of gameplay."""
-    
-    def __init__(self, branch_id: int, game_env: GameMasterEnv, player_models: List[Model]):
-        self.branch_id = branch_id
-        self.game_env = game_env
-        self.player_models = player_models
-        self.completed = False
-        self.error = None
 
 
 def run(game_benchmark: GameBenchmark,
@@ -116,7 +113,7 @@ def run(game_benchmark: GameBenchmark,
         ):
     """
     Run game instances with optional branching.
-    
+
     Args:
         game_benchmark: The game benchmark configuration
         game_instances: Instances to play
@@ -126,143 +123,97 @@ def run(game_benchmark: GameBenchmark,
         branching_condition: A callable(player, env, context) -> bool that determines
             when to branch. If None, no branching occurs. The player parameter gives access
             to the Player object including its model.
-            
+
     Example:
         # Branch when the Describer role is active
         run(..., branching_factor=3, branching_condition=player_role_condition("Describer"))
-        
+
         # Branch when a specific model is active
         run(..., branching_factor=2, branching_condition=player_model_condition("gpt-4"))
-        
+
         # Branch only at first round
         run(..., branching_factor=3, branching_condition=round_condition(1))
-        
+
         # Combine conditions: branch when learner model is active AND it's the first round
         run(..., branching_factor=2, branching_condition=combined_condition(
             player_model_condition("learner-model"),
             round_condition(1)
         ))
-        
+
         # Or use a lambda for custom conditions
         run(..., branching_factor=2, branching_condition=lambda player, **_: player.game_role == "GM")
     """
     callbacks.on_benchmark_start(game_benchmark)
     error_count = 0
-    
     for row in tqdm(game_instances, desc="Playing game instances"):
         try:
-            # Initialize the first branch
             game_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
             game_env.reset(options={
                 "player_models": player_models,
                 "experiment": row["experiment"],
                 "game_instance": row["game_instance"]
             })
-            
             for model in player_models:
                 model.reset()
-            
-            # Track active branches
-            branches = [GameBranch(0, game_env, player_models)]
-            branch_counter = 1
-            has_branched = False
-            
-            # Play all branches
-            while branches:
-                # Process each active branch
-                new_branches = []
-                
-                for branch in branches:
-                    if branch.completed:
-                        continue
-                    
-                    try:
-                        # Get next agent in this branch
-                        agent_iter = branch.game_env.agent_iter()
-                        
-                        for agent_id in agent_iter:
-                            context, reward, termination, truncation, info = branch.game_env.last(observe=True)
-                            
-                            if termination or truncation:
-                                response = None
-                                branch.game_env.step(response)
-                                branch.completed = True
-                                break
-                            
-                            player = branch.game_env.player_by_agent_id[agent_id]
-                            
-                            # Check if we should branch at this step
-                            should_branch = (
-                                not has_branched and 
-                                branching_factor > 1 and 
-                                branching_condition is not None and
-                                branching_condition(player=player, env=branch.game_env, context=context)
-                            )
-                            
-                            if should_branch:
-                                # Create additional branches
-                                for i in range(branching_factor - 1):
-                                    # Create a new game environment for the branch
-                                    new_env = GameMasterEnv(game_benchmark, callbacks=callbacks)
-                                    new_models = [deepcopy(model) for model in branch.player_models]
-                                    
-                                    # Reset with same configuration
-                                    new_env.reset(options={
-                                        "player_models": new_models,
-                                        "experiment": row["experiment"],
-                                        "game_instance": row["game_instance"]
-                                    })
-                                    
-                                    # TODO: Replay history to reach current state
-                                    # This is a simplified version - full implementation would need
-                                    # to replay all previous actions to reach the current game state
-                                    
-                                    new_branch = GameBranch(branch_counter, new_env, new_models)
-                                    new_branches.append(new_branch)
-                                    branch_counter += 1
-                                
-                                has_branched = True
-                                module_logger.info(
-                                    f"Branched instance {row['game_instance']['game_id']} "
-                                    f"into {branching_factor} branches at agent {agent_id}"
-                                )
-                            
-                            # Generate response for current branch
-                            response = player(context)
-                            branch.game_env.step(response)
-                            
-                    except Exception as e:
-                        branch.error = e
-                        branch.completed = True
-                        module_logger.exception(
-                            f"Exception in branch {branch.branch_id} of instance "
-                            f"{row['game_instance']['game_id']}"
-                        )
-                        error_count += 1
-                
-                # Add new branches to active branches
-                branches.extend(new_branches)
-                
-                # Remove completed branches
-                branches = [b for b in branches if not b.completed]
-            
-            # Clean up
-            for branch in branches:
-                branch.game_env.close()
-            
-            # Reset models after all branches complete
-            for model in player_models:
-                model.reset()
-                
+            runner = BranchingRunner(game_env, branching_factor, branching_condition)
+            runner.run()
         except Exception:
             message = f"{game_benchmark.game_name}: Exception for instance {row['game_instance']['game_id']} (but continue)"
             module_logger.exception(message)
             error_count += 1
             for model in player_models:
                 model.reset()
-    
     if error_count > 0:
         stdout_logger.error(
             f"{game_benchmark.game_name}: '{error_count}' exceptions occurred: See clembench.log for details.")
-    
     callbacks.on_benchmark_end(game_benchmark)
+
+
+class BranchingRunner:
+
+    def __init__(
+            self,
+            game_env: GameMasterEnv,
+            branching_factor: int = 1,
+            branching_condition: Optional[BranchingCondition] = None
+    ):
+        self._root = game_env
+        self.branching_factor = branching_factor
+        self.branching_condition = branching_condition
+
+        self._current_envs: List[GameMasterEnv] = [self._root]
+
+    def should_branch(self, game_env):
+        agent_id = game_env.agent_selection
+        player = game_env.player_by_agent_id[agent_id]
+        return (
+                self.branching_factor > 1 and
+                self.branching_condition is not None and
+                self.branching_condition(player=player, env=game_env)
+        )
+
+    def run(self):
+        while self._current_envs:  # As long as we have remaining game envs to be played ...
+            remaining_envs = []
+            for game_env in self._current_envs:  # ... we iterate over all of them
+                if self.should_branch(game_env):  # ... and branch for each game env if necessary
+                    branch_envs = [deepcopy(game_env) for _ in range(self.branching_factor - 1)]
+                else:
+                    branch_envs = [deepcopy(game_env)]  # Note: Still copy to keep single nodes immutable
+                for branch_env in branch_envs:  # ... then we continue the branches, or the game_env itself
+                    agent_id = branch_env.agent_selection  # Only select the next agent
+                    if agent_id is None:  # When there is no agent left, the episode is done for this game env
+                        branch_env.close()
+                        continue
+                    context, reward, termination, truncation, info = game_env.last(observe=True)
+                    if termination or truncation:
+                        # None actions remove the agent from the game during step(None)
+                        # This is essential to observe the final reward, e.g., for the describer, when the guesser wins
+                        response = None
+                    else:
+                        player = branch_env.player_by_agent_id[agent_id]
+                        response = player(context)
+                    branch_env.step(response)
+                    # If we made it to here, then the branch is to be continued (agent_id was not None)
+                    remaining_envs.append(branch_env)
+            self._current_envs = remaining_envs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,5 +65,6 @@ packages = ["clemcore"]
 markers = [
     "api: tests that call external APIs (require keys, cost money)",
     "integration: integration tests with known limitations",
+    "clembench: integration tests requiring clembench games",
 ]
-addopts = "-m 'not api and not integration'"
+addopts = "-m 'not api and not integration and not clembench'"

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -20,7 +20,7 @@ def game_benchmark(game_spec):
 
 @pytest.fixture
 def game_instances(game_spec):
-    return GameInstances.from_game_spec(game_spec).filter(lambda row: row["game_instance"]["game_id"] in [0, 1])
+    return GameInstances.from_game_spec(game_spec).filter(lambda row: row["game_instance"]["game_id"] in [0])
 
 
 @pytest.fixture

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -1,0 +1,42 @@
+import pytest
+
+from clemcore import backends
+from clemcore.clemgame import GameBenchmark, GameRegistry, GameInstances, GameBenchmarkCallbackList
+from clemcore.clemgame.runners import branching
+
+TEST_GAME = "taboo"
+TEST_MODEL = "mock"
+
+
+@pytest.fixture(scope="module")
+def game_spec():
+    return GameRegistry.from_directories_and_cwd_files().get_game_spec(TEST_GAME)
+
+
+@pytest.fixture
+def game_benchmark(game_spec):
+    return GameBenchmark.load_from_spec(game_spec)
+
+
+@pytest.fixture
+def game_instances(game_spec):
+    return GameInstances.from_game_spec(game_spec).filter(lambda row: row["game_instance"]["game_id"] in [0, 1])
+
+
+@pytest.fixture
+def player_models():
+    return backends.load_models([TEST_MODEL] * 2)
+
+
+@pytest.mark.integration
+class TestBranchingRunner:
+
+    def test_branching_runner(self, game_benchmark, game_instances, player_models):
+        branching.run(
+            game_benchmark,
+            game_instances,
+            player_models,
+            callbacks=GameBenchmarkCallbackList(),
+            branching_factor=2,
+            branching_condition=lambda **_: True
+        )

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import pytest
 
 from clemcore import backends
-from clemcore.clemgame import GameBenchmark, GameRegistry, GameInstances, GameBenchmarkCallbackList
+from clemcore.backends import Model
+from clemcore.clemgame import GameBenchmark, GameRegistry, GameInstances, GameBenchmarkCallbackList, EpochResultsFolder, \
+    EpochResultsFolderCallback, InstanceFileSaver, ExperimentFileSaver, InteractionsFileSaver, SignalFileSaver
 from clemcore.clemgame.runners import branching
 
 TEST_GAME = "taboo"
@@ -37,6 +41,25 @@ class TestBranchingRunner:
             game_instances,
             player_models,
             callbacks=GameBenchmarkCallbackList(),
+            branching_factor=2,
+            branching_condition=lambda **_: True
+        )
+
+    def test_branching_runner_with_results_folder(self, game_benchmark, game_instances, player_models):
+        results_folder = EpochResultsFolder(Path("results-branching"), Model.to_identifier(player_models))
+        model_infos = Model.to_infos(player_models)
+        callbacks = GameBenchmarkCallbackList([
+            EpochResultsFolderCallback(results_folder),
+            InstanceFileSaver(results_folder),
+            ExperimentFileSaver(results_folder, player_model_infos=model_infos),
+            InteractionsFileSaver(results_folder, player_model_infos=model_infos, store_branches=True),
+            SignalFileSaver(results_folder)
+        ])
+        branching.run(
+            game_benchmark,
+            game_instances,
+            player_models,
+            callbacks=callbacks,
             branching_factor=2,
             branching_condition=lambda **_: True
         )

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -32,7 +32,7 @@ def player_models():
     return backends.load_models([TEST_MODEL] * 2)
 
 
-@pytest.mark.integration
+@pytest.mark.clembench
 class TestBranchingRunner:
 
     def test_branching_runner(self, game_benchmark, game_instances, player_models):

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -55,6 +55,7 @@ class TestBranchingRunner:
             InteractionsFileSaver(results_folder, player_model_infos=model_infos, store_branches=True),
             SignalFileSaver(results_folder)
         ])
+        # This results in 64 branches for each instance, by branching at each turn and playing 6 turns (2^6=64)
         branching.run(
             game_benchmark,
             game_instances,
@@ -62,4 +63,27 @@ class TestBranchingRunner:
             callbacks=callbacks,
             branching_factor=2,
             branching_condition=lambda **_: True
+        )
+
+    def test_branching_runner_with_results_folder_and_conditions(self, game_benchmark, game_instances, player_models):
+        results_folder = EpochResultsFolder(Path("results-branching"), Model.to_identifier(player_models))
+        model_infos = Model.to_infos(player_models)
+        callbacks = GameBenchmarkCallbackList([
+            EpochResultsFolderCallback(results_folder),
+            InstanceFileSaver(results_folder),
+            ExperimentFileSaver(results_folder, player_model_infos=model_infos),
+            InteractionsFileSaver(results_folder, player_model_infos=model_infos, store_branches=True),
+            SignalFileSaver(results_folder)
+        ])
+        # This results in 8 branches for each instance, by branching only at the first round on the describer's turn
+        branching.run(
+            game_benchmark,
+            game_instances,
+            player_models,
+            callbacks=callbacks,
+            branching_factor=8,
+            branching_condition=branching.combined_condition(
+                branching.is_player_role("WordDescriber"),
+                branching.is_round(0)
+            )
         )


### PR DESCRIPTION
## Summary
This PR introduces the `runners.branching` module. This feature is only accessible via the developers api (not CLI!). 
You can invoke the branching runner like:
```
        branching.run(
            game_benchmark,
            game_instances,
            player_models,
            callbacks=callbacks,
            branching_factor=branching_factor,
            branching_condition=branching_condition
        )
```
where `branching_factor` determines the number of branches to be created when `branching_condition` is met.
For branching condition examples, see `is_player_model`, `is_player_role`, and `is_round` in `runners.branching`.

The general idea is that the whole `GameMasterEnv` is deeply copied at each branching point, except the player's models, and then continued as independent stateful trajectories.

## Callback-related improvements

To make full use of this feature, callbacks can now implement:
```
def on_branching_point(self, game_master: "GameMaster", game_instance: Dict, snapshot: GameSnapshot):
    pass
```
where GameSnapshot captures its origin as `id(game_master)`, the game's state and a timestamp. 

Other callback-related improvements:
- `InteractionsFileSaver` can now be used with the branching runner by setting the `store_branches=True` on init.
- `on_game_end` is now given a `rewards` dictionary that maps agent_id to reward
- `GameStep` now stores also the current player name and model name at that step

## Chore
- Fixed a bug in `GameMasterEnv` where `agent_selection` was not set to `None` after game termination
- `GameState` now captures `current_turn`, `game_name`, `experiment_name` and `game_id`
- The state's `current_turn` is incremented after each step in `GameMaster`

## Tests
- [x] added `test_branching` integration test marked as `clembench` requiring test case
- [x] run playpen trainers depending on branching