### PR TITLE
Remove `-t0.0` suffix from model names in result folder structure

### DIFF
--- a/clemcore/backends/model_registry.py
+++ b/clemcore/backends/model_registry.py
@@ -415,7 +415,7 @@ class Model(abc.ABC):
 
     def __str__(self):
         """Human-readable descriptor of this model."""
-        return f"{self.name}-t{self.temperature}"
+        return f"{self.name}"
 
     @staticmethod
     def to_identifier(player_models: List["Model"]):

--- a/clemcore/backends/model_registry.py
+++ b/clemcore/backends/model_registry.py
@@ -433,7 +433,10 @@ class Model(abc.ABC):
 
     @staticmethod
     def to_infos(player_models: List["Model"]):
-        return {idx: m.model_spec.to_dict() for idx, m in enumerate(player_models)}
+        return {
+            idx: dict(model_spec=m.model_spec.to_dict(), gen_args=m.gen_args)
+            for idx, m in enumerate(player_models)
+        }
 
     @property
     def name(self):


### PR DESCRIPTION
## Summary

This PR removes the `-t` temperature indicator from model names in the result folder structure.

This is particularly useful when evaluating two player games. 

Before:
`results/model1-t0.0--model2-t0.0/game`

Now:
`results/model1--model2/game`

Instead, the temperature as set in the model's `gen_args` is logged in files that store `player_models` information.

These files are `run.json`, `interactions.json`, and `scores.json`.

The information looks like this:

```
"player_models": {
    "0": {
      "model_spec": {
        "model_name": "mock",
        "backend": "_player_programmed"
      },
      "gen_args": {
        "temperature": 0.0,
        "max_tokens": 300
      }
    }
  }
```

## A note on backward compatibility

If users can still include additional information in the result folder structure via model naming.

For example, to include the temperature used during the evaluation run, the user can create a custom model spec, specifying a model name like `model-t0.0`, within the model registry. 

Overall, this enables smoother handling of CLI arguments for addressing specific models.


