### PR TITLE
fix error in the huggingface_local_api.py backend

### DIFF
--- a/clemcore/backends/huggingface_local_api.py
+++ b/clemcore/backends/huggingface_local_api.py
@@ -447,8 +447,8 @@ class HuggingfaceLocalModel(backends.BatchGenerativeModel):
         generation_output: GenerateOutput = self.model.generate(prompt_token_ids, **gen_args)
 
         # Decode all outputs and prompts
-        model_outputs = self.tokenizer.decode(generation_output.sequences)
-        prompt_texts = self.tokenizer.decode(prompt_token_ids)
+        model_outputs = self.tokenizer.batch_decode(generation_output.sequences)
+        prompt_texts = self.tokenizer.batch_decode(prompt_token_ids)
 
         prompts, response_texts, responses = split_and_clean_batch_outputs(self,
                                                                            model_outputs,


### PR DESCRIPTION
The backend is currently broken so that trying to run the clemcore with a Huggingface model does not work.

This is the stacktrace:
```
Errore

2026-03-28 06:59:20,753 - clemcore.clemgame.runners.sequential - ERROR - taboo: Exception for instance 8 (but continue)
Traceback (most recent call last):
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/clemcore/clemgame/runners/sequential.py", line 40, in run
    response = player(context)
               ^^^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/clemcore/clemgame/player.py", line 199, in __call__
    prompt, response_object, response_text = self.model.generate_response(perspective)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/clemcore/backends/utils.py", line 149, in wrapped_fn
    result = generate_response_fn(self, messages, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/clemcore/backends/utils.py", line 117, in wrapped_fn
    return generate_response_fn(self, _messages, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/clemcore/backends/huggingface_local_api.py", line 321, in generate_response
    results = self._generate_batch_response(batch_messages)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/clemcore/backends/huggingface_local_api.py", line 450, in _generate_batch_response
    model_outputs = self.tokenizer.decode(generation_output.sequences)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 4064, in decode
    return self._decode(
           ^^^^^^^^^^^^^
  File "/leonardo_work/IscrC_EVALINT/filippo/clembench/venv/lib/python3.11/site-packages/transformers/tokenization_utils_fast.py", line 682, in _decode
    text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 'ids': 'list' object cannot be interpreted as an integer
```

The fix is easy. It was required to change calls from self.tokenizer.decode to self.tokenizer.batch_decode in the `_generate_batch_response` function.